### PR TITLE
Added titleDivider prop to drawer nav group and updated changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,12 @@
 
 ### Fixed
 
--   Issue with extra large accessibility sizes on iOS [#224](https://github.com/etn-ccis/blui-react-native-component-library/issues/224).
+-   Issue with extra large accessibility sizes on iOS ([#224](https://github.com/etn-ccis/blui-react-native-component-library/issues/224)).
 
 ### Added
 
 -   Added custom children to render inside the header ([#288](https://github.com/etn-ccis/blui-react-native-component-library/issues/288)).
+-   `titleDivider` prop to `<DrawerNavGroup>` component ([#187](https://github.com/etn-ccis/blui-react-native-component-library/issues/187)).
 
 ### Changed
 

--- a/components/src/core/drawer/drawer-nav-group.tsx
+++ b/components/src/core/drawer/drawer-nav-group.tsx
@@ -30,6 +30,9 @@ export type DrawerNavGroupProps = AllSharedProps &
         /** Custom content to use in place of the group header title (if you want to use non-string content) */
         titleContent?: ReactNode;
 
+        /** Whether to show a dividing line below the title */
+        titleDivider?: boolean;
+
         /** Style overrides for internal elements. The styles you provide will be combined with the default styles. */
         styles?: DrawerNavGroupStyles;
     };
@@ -136,6 +139,7 @@ export const DrawerNavGroup: React.FC<DrawerNavGroupProps> = (props) => {
         title,
         titleContent,
         titleColor /* eslint-disable-line @typescript-eslint/no-unused-vars */,
+        titleDivider = true,
         items = [],
         styles = {},
         // Other View Props
@@ -190,7 +194,7 @@ export const DrawerNavGroup: React.FC<DrawerNavGroupProps> = (props) => {
                 {!titleContent && title && (
                     <View style={[defaultStyles.textContent, styles.textContent]}>
                         <Overline style={[defaultStyles.title, styles.title]}>{title}</Overline>
-                        <Divider style={[defaultStyles.divider, styles.divider]} />
+                        {titleDivider && <Divider style={[defaultStyles.divider, styles.divider]} />}
                     </View>
                 )}
                 {items.map((item: NavItem, index: number) => (

--- a/docs/Drawer.md
+++ b/docs/Drawer.md
@@ -179,7 +179,7 @@ The `items` property supports nested items to generate collapsible sections in t
 | title                           | Text to display in the group header                        | `string`    | no       |                             |
 | titleColor                      | Color used for the title text                              | `string`    | no       | varies for light/dark theme |
 | titleContent                    | Custom element, substitute for title                       | `ReactNode` | no       |                             |
-| titleDivider                    | Divider for the title                                      | `boolean`   | no       | true                        |
+| titleDivider                    | Whether to show a divider below the title                  | `boolean`   | no       | true                        |
 | [...sharedProps](#shared-props) | Props that can be set at any level in the drawer hierarchy | -           | -        |                             |
 
 </div>

--- a/docs/Drawer.md
+++ b/docs/Drawer.md
@@ -179,6 +179,7 @@ The `items` property supports nested items to generate collapsible sections in t
 | title                           | Text to display in the group header                        | `string`    | no       |                             |
 | titleColor                      | Color used for the title text                              | `string`    | no       | varies for light/dark theme |
 | titleContent                    | Custom element, substitute for title                       | `ReactNode` | no       |                             |
+| titleDivider                    | Divider for the title                                      | `boolean`   | no       | true                        |
 | [...sharedProps](#shared-props) | Props that can be set at any level in the drawer hierarchy | -           | -        |                             |
 
 </div>


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
Fixes #187 

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- Added titleDivider prop to DrawerNavGroup component

<!-- Include screenshots if they will help illustrate the changes in this PR -->
#### Screenshots / Screen Recording (if applicable)
**titleDivider = false**
<img width="487" alt="Screenshot 2023-01-16 at 2 07 43 PM" src="https://user-images.githubusercontent.com/120575281/212634841-edca7c8a-de2d-4805-b1e1-e4766332bb0c.png">

<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->
#### To Test:
- Checkout [bugfix/187-titleDivider-prop-drawer-nav-group](https://github.com/etn-ccis/blui-react-native-showcase-demo/tree/bugfix/187-titleDivider-prop-drawer-nav-group) branch in blui-react-showcase-demo
- yarn build
- paste dist folder contents to node_modules/@brightlayer-ui/react-native-components
- cd demos/showcase
- cd ios
- pod install
- cd ..
- yarn ios

<!-- Useful for draft pull requests -->
#### Any specific feedback you are looking for?
-


