### PR TITLE
Added on press event to drawer header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 -   Added custom children to render inside the header ([#288](https://github.com/etn-ccis/blui-react-native-component-library/issues/288)).
 -   `titleDivider` prop to `<DrawerNavGroup>` component ([#187](https://github.com/etn-ccis/blui-react-native-component-library/issues/187)).
+-   `onPress` event to `<DrawerHeader>` component ([#84](https://github.com/etn-ccis/blui-react-native-component-library/issues/84)).
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 -   Added custom children to render inside the header ([#288](https://github.com/etn-ccis/blui-react-native-component-library/issues/288)).
 -   `titleDivider` prop to `<DrawerNavGroup>` component ([#187](https://github.com/etn-ccis/blui-react-native-component-library/issues/187)).
--   `onPress` event to `<DrawerHeader>` component ([#84](https://github.com/etn-ccis/blui-react-native-component-library/issues/84)).
+-   `onPress` prop to `<DrawerHeader>` component ([#84](https://github.com/etn-ccis/blui-react-native-component-library/issues/84)).
 
 ### Changed
 

--- a/components/src/core/drawer/drawer-header.tsx
+++ b/components/src/core/drawer/drawer-header.tsx
@@ -8,8 +8,9 @@ import {
     ViewStyle,
     ImageStyle,
     TextStyle,
-    ViewProps,
     TouchableOpacity,
+    TouchableWithoutFeedbackProps,
+    TouchableWithoutFeedback,
 } from 'react-native';
 import { H6, Subtitle1 } from '../typography';
 import { Divider, useTheme } from 'react-native-paper';
@@ -84,7 +85,7 @@ const makeStyles = (
         },
     });
 
-export type DrawerHeaderProps = ViewProps & {
+export type DrawerHeaderProps = TouchableWithoutFeedbackProps & {
     /**
      * The color used for the background
      *
@@ -102,6 +103,9 @@ export type DrawerHeaderProps = ViewProps & {
      * Default: 0.3
      */
     backgroundOpacity?: number;
+
+    /** Callback to execute when the drawer header is pressed */
+    onPress?: () => void;
 
     /** Color to use for header text elements */
     fontColor?: string;
@@ -124,6 +128,7 @@ export type DrawerHeaderProps = ViewProps & {
     /** Style overrides for internal elements. The styles you provide will be combined with the default styles. */
     styles?: {
         root?: StyleProp<ViewStyle>;
+        headerContainer?: StyleProp<ViewStyle>;
         backgroundImageWrapper?: StyleProp<ViewStyle>;
         backgroundImage?: StyleProp<ImageStyle>;
         content?: StyleProp<ViewStyle>;
@@ -153,6 +158,7 @@ export const DrawerHeader: React.FC<DrawerHeaderProps> = (props) => {
         backgroundImage,
         fontColor,
         icon,
+        onPress,
         onIconPress,
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
         backgroundOpacity,
@@ -216,14 +222,16 @@ export const DrawerHeader: React.FC<DrawerHeaderProps> = (props) => {
     }, [backgroundImage, defaultStyles, styles]);
 
     return (
-        <View style={[defaultStyles.root, styles.root, style]} {...viewProps}>
-            {getBackgroundImage()}
-            <View style={[defaultStyles.content, styles.content]}>
-                {icon && getIcon()}
-                {getHeaderContent()}
+        <TouchableWithoutFeedback onPress={onPress}>
+            <View style={[defaultStyles.root, styles.root, style]} {...viewProps}>
+                {getBackgroundImage()}
+                <View style={[defaultStyles.content, styles.content]}>
+                    {icon && getIcon()}
+                    {getHeaderContent()}
+                </View>
+                <Divider />
             </View>
-            <Divider />
-        </View>
+        </TouchableWithoutFeedback>
     );
 };
 

--- a/docs/Drawer.md
+++ b/docs/Drawer.md
@@ -84,18 +84,19 @@ The `<DrawerHeader>` is a subsection that appears at the top of `<Drawer>`. Its 
 
 <div style="overflow: auto">
 
-| Prop Name         | Description                                    | Type                                   | Required | Default                |
-| ----------------- | ---------------------------------------------- | -------------------------------------- | -------- | ---------------------- |
-| backgroundColor   | The color used for the background              | `string`                               | no       | `theme.colors.primary` |
-| backgroundImage   | An image to display in the header              | `ImageSourcePropType`                  | no       |                        |
-| backgroundOpacity | The opacity of the background image            | `number`                               | no       | `0.3`                  |
-| fontColor         | The color of the text elements                 | `string`                               | no       | `theme.colors.surface` |
-| icon              | A component to render for the icon             | [`IconSource`](./Icons.md)             | no       |                        |
-| onIconPress       | A callback to execute when the icon is pressed | `() => void`                           | no       |                        |
-| subtitle          | The second line of text                        | `string`                               | no       |                        |
-| title             | The first line of text                         | `string`                               | no       |                        |
-| titleContent      | Custom content for header title area           | `ReactNode`                            | no       |                        |
-| theme             | Theme value overrides                          | `$DeepPartial<ReactNativePaper.Theme>` | no       |                        |
+| Prop Name         | Description                                      | Type                                   | Required | Default                |
+| ----------------- | ------------------------------------------------ | -------------------------------------- | -------- | ---------------------- |
+| backgroundColor   | The color used for the background                | `string`                               | no       | `theme.colors.primary` |
+| backgroundImage   | An image to display in the header                | `ImageSourcePropType`                  | no       |                        |
+| backgroundOpacity | The opacity of the background image              | `number`                               | no       | `0.3`                  |
+| fontColor         | The color of the text elements                   | `string`                               | no       | `theme.colors.surface` |
+| icon              | A component to render for the icon               | [`IconSource`](./Icons.md)             | no       |                        |
+| onPress           | A callback to execute when the header is pressed | `() => void`                           | no       |                        |
+| onIconPress       | A callback to execute when the icon is pressed   | `() => void`                           | no       |                        |
+| subtitle          | The second line of text                          | `string`                               | no       |                        |
+| title             | The first line of text                           | `string`                               | no       |                        |
+| titleContent      | Custom content for header title area             | `ReactNode`                            | no       |                        |
+| theme             | Theme value overrides                            | `$DeepPartial<ReactNativePaper.Theme>` | no       |                        |
 
 </div>
 


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
Fixes #84

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- Added TouchableWithoutFeedback as a wrapper to drawer header

<!-- Include screenshots if they will help illustrate the changes in this PR -->
#### Screenshots / Screen Recording (if applicable)
**Just to test locally**

https://user-images.githubusercontent.com/120575281/213122457-036be74b-94d2-4a50-a8e2-a132b8ee4358.mov

<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->
#### To Test:
- Checkout [bugfix/84-drawer-header-on-press](https://github.com/etn-ccis/blui-react-native-showcase-demo/tree/bugfix/84-drawer-header-on-press) branch in blui-react-native-showcase-demo
- yarn build
- paste the dist folder content in demos/showcase/node_modules/@brightlayer-ui/react-native-components
- cd demos/showcase/ios
- pod install
- cd ..
- yarn ios
- Click on navigation drawer (left) menu icon to open drawer
- Click on DrawerHeader 
- should fire event onPress

<!-- Useful for draft pull requests -->
#### Any specific feedback you are looking for?
-

**Note:  TouchableWithoutFeedback can only have one child. Instead of replacing the root View, I thought it is better to add TouchableWithoutFeedback as a wrapper**