### PR TITLE
Bugfix/3756 168 wrap props info list item

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 -   `InfoListItemProps` prop to `<DrawerNavItem>` component ([#252](https://github.com/etn-ccis/blui-react-native-component-library/issues/252)).
 -   `titleDivider` prop to `<DrawerNavGroup>` component ([#187](https://github.com/etn-ccis/blui-react-native-component-library/issues/187)).
 -   `onPress` prop to `<DrawerHeader>` component ([#84](https://github.com/etn-ccis/blui-react-native-component-library/issues/84)).
+-   `wrapTitle`, `wrapSubtitle` and `wrapInfo` props to `<InfoListItem>` component ([#168](https://github.com/etn-ccis/blui-react-native-component-library/issues/168)).
 
 ### Changed
 

--- a/components/src/core/info-list-item/info-list-item.tsx
+++ b/components/src/core/info-list-item/info-list-item.tsx
@@ -14,7 +14,7 @@ import { useTheme, Divider as PaperDivider } from 'react-native-paper';
 import { Subtitle1 } from '../typography';
 import * as Colors from '@brightlayer-ui/colors';
 import color from 'color';
-import { renderableSubtitleComponent, withKeys, separate } from './utilities';
+import { renderableSubtitleComponent, renderableInfoComponent, withKeys, separate } from './utilities';
 import { $DeepPartial } from '@callstack/react-theme-provider';
 import { Icon } from '../icon';
 import { IconSource } from '../__types__';
@@ -86,11 +86,13 @@ const infoListItemStyles = (
     avatar: ViewStyle;
     mainContent: ViewStyle;
     flipIcon: ViewStyle;
-}> =>
-    StyleSheet.create({
+}> => {
+    const isWrapEnabled = props.wrapSubtitle || props.wrapTitle || props.wrapInfo;
+    return StyleSheet.create({
         root: {
             backgroundColor: props.backgroundColor || 'transparent',
-            minHeight: (props.dense ? 52 : 72) * fontScale,
+            minHeight: isWrapEnabled ? (props.dense ? 52 : 72) * fontScale : 'auto',
+            height: !isWrapEnabled ? (props.dense ? 52 : 72) * fontScale : 'auto',
             flexDirection: 'row',
             alignItems: 'center',
             paddingRight: 16,
@@ -149,6 +151,7 @@ const infoListItemStyles = (
             transform: [{ scaleX: -1 }],
         },
     });
+};
 
 export type InfoListItemProps = ViewProps & {
     /**
@@ -247,6 +250,24 @@ export type InfoListItemProps = ViewProps & {
     /** The text to show on the first line */
     title: string;
 
+    /** Whether the info line text should wrap to multiple lines on overflow
+     *
+     * Default: false
+     */
+    wrapInfo?: boolean;
+
+    /** Whether the subtitle line text should wrap to multiple lines on overflow
+     *
+     * Default: false
+     */
+    wrapSubtitle?: boolean;
+
+    /** Whether the title line text should wrap to multiple lines on overflow
+     *
+     * Default: false
+     */
+    wrapTitle?: boolean;
+
     /** Style overrides for internal elements. The styles you provide will be combined with the default styles. */
     styles?: {
         root?: StyleProp<ViewStyle>;
@@ -280,13 +301,16 @@ export const InfoListItem: React.FC<InfoListItemProps> = (props) => {
     const {
         avatar,
         title,
+        wrapTitle,
         leftComponent,
         rightComponent,
         chevron,
         divider,
         subtitle,
+        wrapSubtitle,
         subtitleSeparator,
         info,
+        wrapInfo,
         statusColor,
         dense, //eslint-disable-line @typescript-eslint/no-unused-vars
         fontColor, //eslint-disable-line @typescript-eslint/no-unused-vars
@@ -334,7 +358,11 @@ export const InfoListItem: React.FC<InfoListItemProps> = (props) => {
         }
         const subtitleParts = Array.isArray(subtitle) ? [...subtitle] : [subtitle];
         const renderableSubtitleParts = subtitleParts.map((element) =>
-            renderableSubtitleComponent(element, Object.assign({}, defaultStyles.subtitle, styles.subtitle))
+            renderableSubtitleComponent(
+                element,
+                Object.assign({}, defaultStyles.subtitle, styles.subtitle),
+                wrapSubtitle
+            )
         );
 
         return withKeys(separate(renderableSubtitleParts, subtitleSeparator));
@@ -346,7 +374,7 @@ export const InfoListItem: React.FC<InfoListItemProps> = (props) => {
         }
         const infoParts = Array.isArray(info) ? [...info] : [info];
         const renderableInfoParts = infoParts.map((element) =>
-            renderableSubtitleComponent(element, Object.assign({}, defaultStyles.info, styles.info))
+            renderableInfoComponent(element, Object.assign({}, defaultStyles.info, styles.info), wrapInfo)
         );
 
         return withKeys(separate(renderableInfoParts, subtitleSeparator));
@@ -388,7 +416,11 @@ export const InfoListItem: React.FC<InfoListItemProps> = (props) => {
             ) : null}
             {leftComponent}
             <View style={[defaultStyles.mainContent, styles.mainContent]}>
-                <Subtitle1 style={[defaultStyles.title, styles.title]} numberOfLines={1} ellipsizeMode={'tail'}>
+                <Subtitle1
+                    style={[defaultStyles.title, styles.title]}
+                    numberOfLines={wrapTitle ? 0 : 1}
+                    ellipsizeMode={'tail'}
+                >
                     {title}
                 </Subtitle1>
                 <View style={[defaultStyles.subtitleWrapper, styles.subtitleWrapper]}>{getSubtitle()}</View>

--- a/components/src/core/info-list-item/info-list-item.tsx
+++ b/components/src/core/info-list-item/info-list-item.tsx
@@ -95,7 +95,10 @@ const infoListItemStyles = (
             height: !isWrapEnabled ? (props.dense ? 52 : 72) * fontScale : 'auto',
             flexDirection: 'row',
             alignItems: 'center',
+            paddingLeft: 16,
             paddingRight: 16,
+            paddingTop: 8,
+            paddingBottom: 8,
         },
         title: {
             color: props.fontColor || theme.colors.text,

--- a/components/src/core/info-list-item/utilities.tsx
+++ b/components/src/core/info-list-item/utilities.tsx
@@ -3,15 +3,16 @@ import { Body2 } from '../typography';
 import { interleave } from '../helpers/utils';
 import { StyleProp, TextStyle } from 'react-native';
 
-export const renderableSubtitleComponent = (
+const renderBodyComponent = (
     element: React.ReactNode,
-    style?: StyleProp<TextStyle>
+    style?: StyleProp<TextStyle>,
+    isWrapped = false
 ): React.ReactNode => {
     switch (typeof element) {
         case 'string':
         case 'number':
             return (
-                <Body2 numberOfLines={1} style={style}>
+                <Body2 numberOfLines={isWrapped ? 0 : 1} style={style}>
                     {`${element}`}
                 </Body2>
             );
@@ -19,6 +20,18 @@ export const renderableSubtitleComponent = (
             return element;
     }
 };
+
+export const renderableSubtitleComponent = (
+    element: React.ReactNode,
+    style?: StyleProp<TextStyle>,
+    wrapSubtitle = false
+): React.ReactNode => renderBodyComponent(element, style, wrapSubtitle);
+
+export const renderableInfoComponent = (
+    element: React.ReactNode,
+    style?: StyleProp<TextStyle>,
+    wrapInfo = false
+): React.ReactNode => renderBodyComponent(element, style, wrapInfo);
 
 export const interpunct = (separator?: string, style?: StyleProp<TextStyle>): JSX.Element => (
     <Body2 style={[{ marginHorizontal: 4 }, style]}>{separator || '\u00B7'}</Body2>


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
Fixes #168 

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- Added wrapTitle, wrapSubtitle and wrapInfo props to <InfoListItem>
- Updated changelog

<!-- Include screenshots if they will help illustrate the changes in this PR -->
#### Screenshots / Screen Recording (if applicable)
**Before**
![Simulator Screen Shot - iPhone 13 - 2023-01-24 at 14 06 38](https://user-images.githubusercontent.com/120575281/214245898-0154f904-af05-42d0-b41d-5a7e86355cf0.png)

**After wrapTitle=true, wrapSubtitle=true,  wrapInfo=true**
![Simulator Screen Shot - iPhone 13 - 2023-01-24 at 14 09 16](https://user-images.githubusercontent.com/120575281/214246398-0d95be7c-5848-4ce2-a09f-fab7bb7aa2d4.png)

<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->
#### To Test:
- yarn build
- Checkout [bugfix/168-wrap-props-showcase](https://github.com/etn-ccis/blui-react-native-showcase-demo/tree/bugfix/168-wrap-props-showcase) branch in blui-react-native-showcase-demo
- paste dist folder content to node_modules/@brightlayer-ui/react-native-components
- cd demos/showcase
- yarn start
- Pass wrapTitle, wrapSubtitle, wrapInfo props to InfoListItem

<!-- Useful for draft pull requests -->
#### Any specific feedback you are looking for?
-


