### PR TITLE
Blend header background with statusBar on Android devices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 -   Issue with extra large accessibility sizes on iOS ([#224](https://github.com/etn-ccis/blui-react-native-component-library/issues/224)).
+-   Issue with the `<Header>` not blending behind the StatusBar on android devices([#186](https://github.com/etn-ccis/blui-react-native-component-library/issues/186)). 
 
 ### Added
 

--- a/components/src/core/header/header.tsx
+++ b/components/src/core/header/header.tsx
@@ -13,6 +13,7 @@ import {
     TextStyle,
     ImageStyle,
     TextInputProps,
+    Platform,
 } from 'react-native';
 import color from 'color';
 import { useTheme } from 'react-native-paper';
@@ -56,6 +57,7 @@ const headerStyles = (
             shadowRadius: 2,
             shadowOpacity: 1,
             elevation: 0,
+            paddingTop: Platform.OS === 'android' ? StatusBar.currentHeight : 0,
         },
         content: {
             flex: 1,
@@ -682,7 +684,7 @@ export const Header: React.FC<HeaderProps> = (props) => {
 
     return (
         <>
-            <StatusBar barStyle={statusBarStyle()} />
+            <StatusBar barStyle={statusBarStyle()} translucent backgroundColor={'transparent'} />
             <TouchableWithoutFeedback
                 accessible={false}
                 onPress={(): void => onPress()}


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
Fixes BLUI-3757 && #186.

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- Blend header background with statusBar on Android devices
- 
- 

<!-- Include screenshots if they will help illustrate the changes in this PR -->
#### Screenshots / Screen Recording (if applicable)
-
<img width="203" alt="Screen Shot 2023-01-30 at 1 36 41 PM" src="https://user-images.githubusercontent.com/13989985/215568951-f16bb209-4fab-4a78-8f8a-2ad59723876b.png">
<img width="222" alt="Screen Shot 2023-01-30 at 1 36 09 PM" src="https://user-images.githubusercontent.com/13989985/215568953-38840967-2005-486d-9d84-31dbe200921f.png">


![Simulator Screen Shot - iPhone 12 - 2023-01-30 at 13 43 11](https://user-images.githubusercontent.com/13989985/215568956-83993b85-16dc-4c9f-8b67-e211525e26db.png)
![Simulator Screen Shot - iPhone 12 - 2023-01-30 at 13 30 08](https://user-images.githubusercontent.com/13989985/215569253-544320e6-6648-44d6-8a42-4e72683fab35.png)


<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->
#### To Test:
- `yarn start:showcase-android` 
- Check that the header background covers the entire header including the status bar area
- Please check on as many emulators/devices as you're willing to (at least 2)
- `yarn start:showcase`
-  Check that the header doesn't have any breaking changes on iOS.

Mess around with different background colors or images in the showcase and double check the open and closed states on both

