### PR TITLE
build library with md3 instead of core

### DIFF
--- a/components/package.json
+++ b/components/package.json
@@ -17,8 +17,8 @@
     },
     "homepage": "https://github.com/etn-ccis/blui-react-native-component-library#readme",
     "license": "BSD-3-Clause",
-    "main": "core/index.js",
-    "types": "core/index.d.ts",
+    "main": "md3/index.js",
+    "types": "md3/index.d.ts",
     "scripts": {
         "lint": "eslint \"src/**/*.{ts,tsx}\"",
         "lint:fix": "eslint \"src/**/*.{ts,tsx}\" --fix",


### PR DESCRIPTION
<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- build library with md3 instead of core

<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->
#### To Test:
- yarn start:showcase and ensure that the package is built with the md3 folder instead of core and that the showcase runs


