### PR TITLE
Feature/blui 4367 header md3

### DIFF
--- a/components/src/md3/Header/Header.tsx
+++ b/components/src/md3/Header/Header.tsx
@@ -1,19 +1,19 @@
 import React, { useCallback, useState, useRef, useEffect, ReactNode } from 'react';
 import {
-  Animated,
-  ImageSourcePropType,
-  SafeAreaView,
-  StyleSheet,
-  StatusBar,
-  TextInput,
-  TouchableWithoutFeedback,
-  ViewProps,
-  StyleProp,
-  ViewStyle,
-  TextStyle,
-  ImageStyle,
-  TextInputProps,
-  Platform,
+    Animated,
+    ImageSourcePropType,
+    SafeAreaView,
+    StyleSheet,
+    StatusBar,
+    TextInput,
+    TouchableWithoutFeedback,
+    ViewProps,
+    StyleProp,
+    ViewStyle,
+    TextStyle,
+    ImageStyle,
+    TextInputProps,
+    Platform,
 } from 'react-native';
 import color from 'color';
 import { MD3Theme, useTheme } from 'react-native-paper';
@@ -33,235 +33,234 @@ import { useFontScale } from '../__contexts__/font-scale-context';
 const AnimatedSafeAreaView = Animated.createAnimatedComponent(SafeAreaView);
 
 const headerStyles = (
-  props: HeaderProps,
-  theme: MD3Theme,
-  fontScale: number
+    props: HeaderProps,
+    theme: MD3Theme,
+    fontScale: number
 ): StyleSheet.NamedStyles<{
-  root: ViewStyle;
-  content: ViewStyle;
-  search: ViewStyle;
+    root: ViewStyle;
+    content: ViewStyle;
+    search: ViewStyle;
 }> => {
-  return {
-    root: {
-      width: '100%',
-      backgroundColor:
-        props.backgroundColor ||
-        // @change color once have a correct color
-        // (theme.dark ? theme.colors.actionPalette?.active || theme.colors.surface : theme.colors.primary),
-        (theme.dark ? theme.colors.surface : theme.colors.primary),
-      shadowColor: 'rgba(0, 0, 0, 0.3)',
-      shadowOffset: {
-        width: 0,
-        height: 1,
-      },
-      shadowRadius: 2,
-      shadowOpacity: 1,
-      elevation: 0,
-      paddingTop: Platform.OS === 'android' ? StatusBar.currentHeight : 0,
-    },
-    content: {
-      flex: 1,
-      paddingHorizontal: 16,
-      flexDirection: 'row',
-      minHeight: 56 * fontScale,
-    },
-    search: {
-      flex: 1,
-      flexDirection: 'row',
-      alignItems: 'center',
-      paddingHorizontal: 16,
-    },
-  };
+    return {
+        root: {
+            width: '100%',
+            backgroundColor:
+                props.backgroundColor ||
+                // @change color once have a correct color
+                // (theme.dark ? theme.colors.actionPalette?.active || theme.colors.surface : theme.colors.primary),
+                (theme.dark ? theme.colors.surface : theme.colors.primary),
+            shadowColor: 'rgba(0, 0, 0, 0.3)',
+            shadowOffset: {
+                width: 0,
+                height: 1,
+            },
+            shadowRadius: 2,
+            shadowOpacity: 1,
+            elevation: 0,
+            paddingTop: Platform.OS === 'android' ? StatusBar.currentHeight : 0,
+        },
+        content: {
+            flex: 1,
+            paddingHorizontal: 16,
+            flexDirection: 'row',
+            minHeight: 56 * fontScale,
+        },
+        search: {
+            flex: 1,
+            flexDirection: 'row',
+            alignItems: 'center',
+            paddingHorizontal: 16,
+        },
+    };
 };
 
 export type SearchableConfig = {
-  /**
-   * Determines how the search input will be capitalized
-   *
-   * Default: 'none'
-   */
-  autoCapitalize?: TextInputProps['autoCapitalize'];
+    /**
+     * Determines how the search input will be capitalized
+     *
+     * Default: 'none'
+     */
+    autoCapitalize?: TextInputProps['autoCapitalize'];
 
-  /**
-   * Determines whether auto-correct is enabled in the search input
-   *
-   * Default: false
-   */
-  autoCorrect?: boolean;
+    /**
+     * Determines whether auto-correct is enabled in the search input
+     *
+     * Default: false
+     */
+    autoCorrect?: boolean;
 
-  /**
-   * Determines whether the search input will be focused on when it is rendered / opened
-   *
-   * Default: false
-   */
-  autoFocus?: boolean;
+    /**
+     * Determines whether the search input will be focused on when it is rendered / opened
+     *
+     * Default: false
+     */
+    autoFocus?: boolean;
 
-  /** Icon to override default search icon */
-  icon?: IconSource;
+    /** Icon to override default search icon */
+    icon?: IconSource;
 
-  /** Callback for when the text in the search input changes */
-  onChangeText?: (text: string) => void;
+    /** Callback for when the text in the search input changes */
+    onChangeText?: (text: string) => void;
 
-  /**
-   * Placeholder text for the search input
-   *
-   * Default: 'Search'
-   */
-  placeholder?: string;
+    /**
+     * Placeholder text for the search input
+     *
+     * Default: 'Search'
+     */
+    placeholder?: string;
 };
 
-
 export type HeaderProps = ViewProps & {
-  /** Array of icons / actions to display on the right */
-  actionItems?: Array<HeaderIcon | HeaderActionComponent>;
+    /** Array of icons / actions to display on the right */
+    actionItems?: Array<HeaderIcon | HeaderActionComponent>;
 
-  /**
-   * The color used for the background
-   *
-   * Default: Theme.colors.primary
-   */
-  backgroundColor?: string;
+    /**
+     * The color used for the background
+     *
+     * Default: Theme.colors.primary
+     */
+    backgroundColor?: string;
 
-  /**
-   * An image to blend with the colored background in the header
-   */
-  backgroundImage?: ImageSourcePropType;
+    /**
+     * An image to blend with the colored background in the header
+     */
+    backgroundImage?: ImageSourcePropType;
 
-  /**
-   * Height of the Header when fully collapsed
-   *
-   * Default: 56
-   */
-  collapsedHeight?: number;
+    /**
+     * Height of the Header when fully collapsed
+     *
+     * Default: 56
+     */
+    collapsedHeight?: number;
 
-  /**
-   * Allow the header to be expanded / collapsed by tapping
-   *
-   * Default: false
-   */
-  expandable?: boolean;
+    /**
+     * Allow the header to be expanded / collapsed by tapping
+     *
+     * Default: false
+     */
+    expandable?: boolean;
 
-  /**
-   * Height of the Header when fully expanded
-   *
-   * Default: 200
-   */
-  expandedHeight?: number;
+    /**
+     * Height of the Header when fully expanded
+     *
+     * Default: 200
+     */
+    expandedHeight?: number;
 
-  /**
-   * Color of the title, subtitle, info, and icons in the header
-   *
-   * Default: Theme.colors.onPrimary
-   */
-  fontColor?: string;
+    /**
+     * Color of the title, subtitle, info, and icons in the header
+     *
+     * Default: Theme.colors.onPrimary
+     */
+    fontColor?: string;
 
-  /** Optional header third line of text (hidden when collapsed) */
-  info?: ReactNode;
+    /** Optional header third line of text (hidden when collapsed) */
+    info?: ReactNode;
 
-  /** Icon to show to the left of the title, primarily used to trigger the menu / drawer */
-  icon?: IconSource;
+    /** Icon to show to the left of the title, primarily used to trigger the menu / drawer */
+    icon?: IconSource;
 
-  /** Callback to execute when the icon is pressed */
-  onIconPress?: () => void;
+    /** Callback to execute when the icon is pressed */
+    onIconPress?: () => void;
 
-  /**
-   * Y-value of the scroll position of the linked ScrollView (dynamic variant only)
-   */
-  scrollPosition?: Animated.Value;
+    /**
+     * Y-value of the scroll position of the linked ScrollView (dynamic variant only)
+     */
+    scrollPosition?: Animated.Value;
 
-  /** Configuration object for search behavior */
-  searchableConfig?: SearchableConfig;
+    /** Configuration object for search behavior */
+    searchableConfig?: SearchableConfig;
 
-  /**
-   * Renders the header in the expanded state to start
-   *
-   * Default: false
-   */
-  startExpanded?: boolean;
+    /**
+     * Renders the header in the expanded state to start
+     *
+     * Default: false
+     */
+    startExpanded?: boolean;
 
-  /** Style overrides for internal elements. The styles you provide will be combined with the default styles. */
-  styles?: {
-      root?: StyleProp<ViewStyle>;
-      backgroundImage?: StyleProp<ImageStyle>;
-      component?: StyleProp<ViewStyle>;
-      content?: StyleProp<ViewStyle>;
-      icon?: StyleProp<ViewStyle>;
-      textContent?: StyleProp<ViewStyle>;
-      title?: StyleProp<TextStyle>;
-      subtitle?: StyleProp<TextStyle>;
-      info?: StyleProp<TextStyle>;
-      search?: StyleProp<TextStyle>;
-      actionPanel?: StyleProp<ViewStyle>;
-      actionItem?: StyleProp<ViewStyle>;
-  };
+    /** Style overrides for internal elements. The styles you provide will be combined with the default styles. */
+    styles?: {
+        root?: StyleProp<ViewStyle>;
+        backgroundImage?: StyleProp<ImageStyle>;
+        component?: StyleProp<ViewStyle>;
+        content?: StyleProp<ViewStyle>;
+        icon?: StyleProp<ViewStyle>;
+        textContent?: StyleProp<ViewStyle>;
+        title?: StyleProp<TextStyle>;
+        subtitle?: StyleProp<TextStyle>;
+        info?: StyleProp<TextStyle>;
+        search?: StyleProp<TextStyle>;
+        actionPanel?: StyleProp<ViewStyle>;
+        actionItem?: StyleProp<ViewStyle>;
+    };
 
-  /** The text to display on the second line */
-  subtitle?: ReactNode;
+    /** The text to display on the second line */
+    subtitle?: ReactNode;
 
-  /**
-   * Theme value overrides specific to this component.
-   */
-  theme?: $DeepPartial<MD3Theme>;
+    /**
+     * Theme value overrides specific to this component.
+     */
+    theme?: $DeepPartial<MD3Theme>;
 
-  /** The test to display on the first line */
-  title: ReactNode;
+    /** The test to display on the first line */
+    title: ReactNode;
 
-  /**
-   * Callback function to make updates to the linked scrollView (dynamic variant only)
-   */
-  updateScrollView?: (data: { padding: number | null; animate: boolean; scrollTo: number | null }) => void;
+    /**
+     * Callback function to make updates to the linked scrollView (dynamic variant only)
+     */
+    updateScrollView?: (data: { padding: number | null; animate: boolean; scrollTo: number | null }) => void;
 
-  /**
-   * Current resize mode of the Header:
-   * - 'static': Header does not resize based on scroll position,
-   * - 'dynamic' Header resizes based on the provided scrollPosition.
-   *
-   * Default: static
-   */
-  variant?: 'dynamic' | 'static';
+    /**
+     * Current resize mode of the Header:
+     * - 'static': Header does not resize based on scroll position,
+     * - 'dynamic' Header resizes based on the provided scrollPosition.
+     *
+     * Default: static
+     */
+    variant?: 'dynamic' | 'static';
 
-  /**
-   * @experimental
-   *
-   * Set to true to use the alternative subtitle styling (larger size, light weight)
-   */
-  washingtonStyle?: boolean;
+    /**
+     * @experimental
+     *
+     * Set to true to use the alternative subtitle styling (larger size, light weight)
+     */
+    washingtonStyle?: boolean;
 };
 
 export const Header: React.FC<HeaderProps> = (props) => {
-  const {
-    actionItems,
-    backgroundColor,
-    backgroundImage,
-    expandable = false,
-    expandedHeight: expandedHeightProp = 200,
-    collapsedHeight: collapsedHeightProp = 56,
-    fontColor,
-    info,
-    icon,
-    onIconPress,
-    scrollPosition = new Animated.Value(0),
-    searchableConfig,
-    startExpanded,
-    subtitle,
-    style,
-    styles = {},
-    theme: themeOverride,
-    title,
-    variant = 'static',
-    washingtonStyle,
-    updateScrollView = (): void => {},
-    ...viewProps
-  } = props;
+    const {
+        actionItems,
+        backgroundColor,
+        backgroundImage,
+        expandable = false,
+        expandedHeight: expandedHeightProp = 200,
+        collapsedHeight: collapsedHeightProp = 56,
+        fontColor,
+        info,
+        icon,
+        onIconPress,
+        scrollPosition = new Animated.Value(0),
+        searchableConfig,
+        startExpanded,
+        subtitle,
+        style,
+        styles = {},
+        theme: themeOverride,
+        title,
+        variant = 'static',
+        washingtonStyle,
+        updateScrollView = (): void => {},
+        ...viewProps
+    } = props;
 
-  const { getScaledHeight, LANDSCAPE } = useHeaderDimensions();
-  const fontScale = useFontScale();
+    const { getScaledHeight, LANDSCAPE } = useHeaderDimensions();
+    const fontScale = useFontScale();
 
-  const theme = useTheme(themeOverride);
-  const defaultStyles = headerStyles(props, theme, fontScale);
-  const searchRef = useRef<TextInput>(null);
+    const theme = useTheme(themeOverride);
+    const defaultStyles = headerStyles(props, theme, fontScale);
+    const searchRef = useRef<TextInput>(null);
 
-  const collapsedHeight = getScaledHeight(collapsedHeightProp);
+    const collapsedHeight = getScaledHeight(collapsedHeightProp);
     const previousCollapsedHeight = usePrevious(collapsedHeight);
     const expandedHeight = getScaledHeight(expandedHeightProp);
     const previousExpandedHeight = usePrevious(expandedHeight);
@@ -505,13 +504,13 @@ export const Header: React.FC<HeaderProps> = (props) => {
         return (
             backgroundColor ||
             // (theme.dark ? theme.colors.actionPalette?.active || theme.colors.surface : theme.colors.primary)
-        (theme.dark ? theme.colors.surface : theme.colors.primary)
+            (theme.dark ? theme.colors.surface : theme.colors.primary)
         );
     }, [searching, theme, backgroundColor]);
 
     const getFontColor = useCallback((): string => {
         if (searching) {
-          // @change color once have a correct color
+            // @change color once have a correct color
             return theme.colors.onSurface;
         }
         return fontColor || 'white';
@@ -756,6 +755,5 @@ export const Header: React.FC<HeaderProps> = (props) => {
             </TouchableWithoutFeedback>
         </>
     );
-
 };
 Header.displayName = 'Header';

--- a/components/src/md3/Header/Header.tsx
+++ b/components/src/md3/Header/Header.tsx
@@ -1,0 +1,761 @@
+import React, { useCallback, useState, useRef, useEffect, ReactNode } from 'react';
+import {
+  Animated,
+  ImageSourcePropType,
+  SafeAreaView,
+  StyleSheet,
+  StatusBar,
+  TextInput,
+  TouchableWithoutFeedback,
+  ViewProps,
+  StyleProp,
+  ViewStyle,
+  TextStyle,
+  ImageStyle,
+  TextInputProps,
+  Platform,
+} from 'react-native';
+import color from 'color';
+import { MD3Theme, useTheme } from 'react-native-paper';
+import { ANIMATION_LENGTH } from './constants';
+import { HeaderBackgroundImage } from './headerBackgroundImage';
+import { HeaderNavigationIcon } from './headerNavigationIcon';
+import { HeaderContent } from './headerContent';
+import { HeaderActionItems } from './headerActionItems';
+import { SearchContext } from './contexts/SearchContextProvider';
+import { ColorContext } from './contexts/ColorContextProvider';
+import { HeaderHeightContext } from './contexts/HeaderHeightContextProvider';
+import { HeaderActionComponent, HeaderIcon, IconSource } from '../__types__';
+import { $DeepPartial } from '@callstack/react-theme-provider';
+import { usePrevious } from '../__hooks__/usePrevious';
+import { useHeaderDimensions } from '../__hooks__/useHeaderDimensions';
+import { useFontScale } from '../__contexts__/font-scale-context';
+const AnimatedSafeAreaView = Animated.createAnimatedComponent(SafeAreaView);
+
+const headerStyles = (
+  props: HeaderProps,
+  theme: MD3Theme,
+  fontScale: number
+): StyleSheet.NamedStyles<{
+  root: ViewStyle;
+  content: ViewStyle;
+  search: ViewStyle;
+}> => {
+  return {
+    root: {
+      width: '100%',
+      backgroundColor:
+        props.backgroundColor ||
+        // @change color once have a correct color
+        // (theme.dark ? theme.colors.actionPalette?.active || theme.colors.surface : theme.colors.primary),
+        (theme.dark ? theme.colors.surface : theme.colors.primary),
+      shadowColor: 'rgba(0, 0, 0, 0.3)',
+      shadowOffset: {
+        width: 0,
+        height: 1,
+      },
+      shadowRadius: 2,
+      shadowOpacity: 1,
+      elevation: 0,
+      paddingTop: Platform.OS === 'android' ? StatusBar.currentHeight : 0,
+    },
+    content: {
+      flex: 1,
+      paddingHorizontal: 16,
+      flexDirection: 'row',
+      minHeight: 56 * fontScale,
+    },
+    search: {
+      flex: 1,
+      flexDirection: 'row',
+      alignItems: 'center',
+      paddingHorizontal: 16,
+    },
+  };
+};
+
+export type SearchableConfig = {
+  /**
+   * Determines how the search input will be capitalized
+   *
+   * Default: 'none'
+   */
+  autoCapitalize?: TextInputProps['autoCapitalize'];
+
+  /**
+   * Determines whether auto-correct is enabled in the search input
+   *
+   * Default: false
+   */
+  autoCorrect?: boolean;
+
+  /**
+   * Determines whether the search input will be focused on when it is rendered / opened
+   *
+   * Default: false
+   */
+  autoFocus?: boolean;
+
+  /** Icon to override default search icon */
+  icon?: IconSource;
+
+  /** Callback for when the text in the search input changes */
+  onChangeText?: (text: string) => void;
+
+  /**
+   * Placeholder text for the search input
+   *
+   * Default: 'Search'
+   */
+  placeholder?: string;
+};
+
+
+export type HeaderProps = ViewProps & {
+  /** Array of icons / actions to display on the right */
+  actionItems?: Array<HeaderIcon | HeaderActionComponent>;
+
+  /**
+   * The color used for the background
+   *
+   * Default: Theme.colors.primary
+   */
+  backgroundColor?: string;
+
+  /**
+   * An image to blend with the colored background in the header
+   */
+  backgroundImage?: ImageSourcePropType;
+
+  /**
+   * Height of the Header when fully collapsed
+   *
+   * Default: 56
+   */
+  collapsedHeight?: number;
+
+  /**
+   * Allow the header to be expanded / collapsed by tapping
+   *
+   * Default: false
+   */
+  expandable?: boolean;
+
+  /**
+   * Height of the Header when fully expanded
+   *
+   * Default: 200
+   */
+  expandedHeight?: number;
+
+  /**
+   * Color of the title, subtitle, info, and icons in the header
+   *
+   * Default: Theme.colors.onPrimary
+   */
+  fontColor?: string;
+
+  /** Optional header third line of text (hidden when collapsed) */
+  info?: ReactNode;
+
+  /** Icon to show to the left of the title, primarily used to trigger the menu / drawer */
+  icon?: IconSource;
+
+  /** Callback to execute when the icon is pressed */
+  onIconPress?: () => void;
+
+  /**
+   * Y-value of the scroll position of the linked ScrollView (dynamic variant only)
+   */
+  scrollPosition?: Animated.Value;
+
+  /** Configuration object for search behavior */
+  searchableConfig?: SearchableConfig;
+
+  /**
+   * Renders the header in the expanded state to start
+   *
+   * Default: false
+   */
+  startExpanded?: boolean;
+
+  /** Style overrides for internal elements. The styles you provide will be combined with the default styles. */
+  styles?: {
+      root?: StyleProp<ViewStyle>;
+      backgroundImage?: StyleProp<ImageStyle>;
+      component?: StyleProp<ViewStyle>;
+      content?: StyleProp<ViewStyle>;
+      icon?: StyleProp<ViewStyle>;
+      textContent?: StyleProp<ViewStyle>;
+      title?: StyleProp<TextStyle>;
+      subtitle?: StyleProp<TextStyle>;
+      info?: StyleProp<TextStyle>;
+      search?: StyleProp<TextStyle>;
+      actionPanel?: StyleProp<ViewStyle>;
+      actionItem?: StyleProp<ViewStyle>;
+  };
+
+  /** The text to display on the second line */
+  subtitle?: ReactNode;
+
+  /**
+   * Theme value overrides specific to this component.
+   */
+  theme?: $DeepPartial<MD3Theme>;
+
+  /** The test to display on the first line */
+  title: ReactNode;
+
+  /**
+   * Callback function to make updates to the linked scrollView (dynamic variant only)
+   */
+  updateScrollView?: (data: { padding: number | null; animate: boolean; scrollTo: number | null }) => void;
+
+  /**
+   * Current resize mode of the Header:
+   * - 'static': Header does not resize based on scroll position,
+   * - 'dynamic' Header resizes based on the provided scrollPosition.
+   *
+   * Default: static
+   */
+  variant?: 'dynamic' | 'static';
+
+  /**
+   * @experimental
+   *
+   * Set to true to use the alternative subtitle styling (larger size, light weight)
+   */
+  washingtonStyle?: boolean;
+};
+
+export const Header: React.FC<HeaderProps> = (props) => {
+  const {
+    actionItems,
+    backgroundColor,
+    backgroundImage,
+    expandable = false,
+    expandedHeight: expandedHeightProp = 200,
+    collapsedHeight: collapsedHeightProp = 56,
+    fontColor,
+    info,
+    icon,
+    onIconPress,
+    scrollPosition = new Animated.Value(0),
+    searchableConfig,
+    startExpanded,
+    subtitle,
+    style,
+    styles = {},
+    theme: themeOverride,
+    title,
+    variant = 'static',
+    washingtonStyle,
+    updateScrollView = (): void => {},
+    ...viewProps
+  } = props;
+
+  const { getScaledHeight, LANDSCAPE } = useHeaderDimensions();
+  const fontScale = useFontScale();
+
+  const theme = useTheme(themeOverride);
+  const defaultStyles = headerStyles(props, theme, fontScale);
+  const searchRef = useRef<TextInput>(null);
+
+  const collapsedHeight = getScaledHeight(collapsedHeightProp);
+    const previousCollapsedHeight = usePrevious(collapsedHeight);
+    const expandedHeight = getScaledHeight(expandedHeightProp);
+    const previousExpandedHeight = usePrevious(expandedHeight);
+    const scrollableDistance = expandedHeight - collapsedHeight;
+    const previousScrollableDistance = usePrevious(scrollableDistance);
+    const dynamicHeaderHeight = Animated.subtract(new Animated.Value(expandedHeight), scrollPosition);
+
+    // Local State
+    const [staticHeaderHeightValue, setStaticHeaderHeightValue] = useState(
+        startExpanded ? expandedHeight : collapsedHeight
+    );
+    const [scrollPositionValue, setScrollPositionValue] = useState(0);
+    const inDynamicRange = scrollPositionValue <= scrollableDistance;
+    const [searching, setSearching] = useState(false);
+    const expanded = staticHeaderHeightValue === expandedHeight;
+    const [manuallyExpanded, setManuallyExpanded] = useState(false);
+    const [previousExpanded, setPreviousExpanded] = useState(expanded);
+    const [useStaticHeight, setUseStaticHeight] = useState(variant === 'static');
+    const [query, setQuery] = useState('');
+    const [staticHeaderHeight] = useState(
+        startExpanded ? new Animated.Value(expandedHeight) : new Animated.Value(collapsedHeight)
+    );
+
+    // Animation functions to smoothly transition the static Header height
+    const expand = Animated.timing(staticHeaderHeight, {
+        toValue: expandedHeight,
+        duration: ANIMATION_LENGTH,
+        useNativeDriver: false,
+    });
+    const contract = Animated.timing(staticHeaderHeight, {
+        toValue: collapsedHeight,
+        duration: ANIMATION_LENGTH,
+        useNativeDriver: false,
+    });
+
+    /* UTILITY FUNCTIONS */
+
+    // returns the count of each type of actionItem (component and icon) and the total width of components
+    const getActionItemInfo = useCallback((): {
+        components: { count: number; width: number };
+        icons: { count: number };
+    } => {
+        if (!actionItems) return { components: { count: 0, width: 0 }, icons: { count: 0 } };
+
+        const actionComponents: HeaderActionComponent[] = actionItems.filter(
+            (item) => (item as HeaderActionComponent).component
+        ) as HeaderActionComponent[];
+
+        const componentsCount = actionComponents.length;
+        const componentsWidth = actionComponents.reduce(
+            (accumulator: number, currentValue: HeaderActionComponent) =>
+                accumulator + (currentValue.width || 40 * fontScale),
+            0
+        );
+        return {
+            components: { count: componentsCount, width: componentsWidth },
+            icons: { count: actionItems.length - componentsCount },
+        };
+    }, [actionItems]);
+
+    /* EVENT LISTENERS */
+
+    // if variant is changed, make the necessary updates to sizing, margins, etc.
+    useEffect(() => {
+        // Going from dynamic -> static
+        if (variant === 'static') {
+            setUseStaticHeight(true);
+            if (!inDynamicRange) {
+                if (!expanded) {
+                    updateScrollView({
+                        padding: collapsedHeight,
+                        animate: false,
+                        scrollTo: scrollPositionValue - scrollableDistance,
+                    });
+                }
+            } else {
+                // less than halfway through the dynamic range -> use expanded
+                if (scrollPositionValue <= scrollableDistance / 2) {
+                    if (expanded) {
+                        updateScrollView({ padding: expandedHeight, animate: false, scrollTo: 0 });
+                    }
+                }
+                // more than halfway through the dynamic range -> use collapsed
+                else if (!expanded) {
+                    updateScrollView({ padding: collapsedHeight, animate: false, scrollTo: 0 });
+                }
+            }
+        }
+        // Going from static -> dynamic
+        else {
+            if (!inDynamicRange) {
+                setUseStaticHeight(true);
+                if (!expanded) {
+                    updateScrollView({
+                        padding: expandedHeight,
+                        animate: false,
+                        scrollTo: scrollPositionValue + scrollableDistance,
+                    });
+                }
+            } else {
+                setUseStaticHeight(false);
+                if (expanded) {
+                    staticHeaderHeight.setValue(
+                        scrollPositionValue <= scrollableDistance / 2 ? expandedHeight : collapsedHeight
+                    );
+                    updateScrollView({
+                        padding: expandedHeight,
+                        animate: false,
+                        scrollTo: scrollPositionValue <= scrollableDistance / 2 ? 0 : scrollableDistance,
+                    });
+                } else {
+                    updateScrollView({
+                        padding: expandedHeight,
+                        animate: false,
+                        scrollTo: scrollPositionValue <= scrollableDistance / 2 ? 0 : scrollableDistance,
+                    });
+                }
+            }
+        }
+    }, [variant]);
+
+    // if either height property is changed (or orientation), make the necessary updates to sizing, margins, etc.
+    useEffect(() => {
+        // don't execute this logic on the first render
+        if (previousExpandedHeight === undefined || previousCollapsedHeight === undefined) return;
+
+        const wasExpanded = staticHeaderHeightValue === previousExpandedHeight;
+        staticHeaderHeight.setValue(wasExpanded ? expandedHeight : collapsedHeight);
+
+        if (wasExpanded) expand.start();
+        else contract.start();
+
+        const scrollableDifference = scrollableDistance - (previousScrollableDistance || scrollableDistance);
+        const expandedDifference = expandedHeight - (previousExpandedHeight || expandedHeight);
+        const collapsedDifference = collapsedHeight - (previousCollapsedHeight || collapsedHeight);
+
+        // was in the dynamic range
+        if (scrollPositionValue <= (previousScrollableDistance || scrollableDistance)) {
+            updateScrollView({
+                padding: variant === 'dynamic' || wasExpanded ? expandedHeight : collapsedHeight,
+                animate: false,
+                scrollTo:
+                    variant === 'dynamic'
+                        ? wasExpanded
+                            ? -1 // workaround because if we pass 0 the ScrollView won't update because it thinks the scroll position is the same as before
+                            : scrollableDistance
+                        : scrollPositionValue + scrollableDifference,
+            });
+        } else {
+            if (variant === 'static') {
+                updateScrollView({
+                    padding: wasExpanded ? expandedHeight : collapsedHeight,
+                    animate: false,
+                    scrollTo: scrollPositionValue + (wasExpanded ? expandedDifference : collapsedDifference),
+                });
+            } else {
+                updateScrollView({
+                    padding: expandedHeight,
+                    animate: false,
+                    scrollTo: scrollPositionValue + expandedDifference,
+                });
+            }
+        }
+    }, [expandedHeight, collapsedHeight, LANDSCAPE]);
+
+    // Track the current value of the Animated header height
+    const onHeightChange = useCallback(({ value: newHeight }: { value: number }) => {
+        setStaticHeaderHeightValue(newHeight);
+    }, []);
+
+    // Make updates based on changes in the scroll position
+    const onScrollChange = useCallback(
+        ({ value: scrollValue }: { value: number }) => {
+            // save the current value of the animated scroll position
+            setScrollPositionValue(scrollValue);
+
+            if (variant !== 'dynamic' || searching) return;
+
+            if (scrollValue <= scrollableDistance) {
+                if (manuallyExpanded) {
+                    if (!useStaticHeight) setUseStaticHeight(true);
+                    if (scrollValue <= 0) {
+                        setUseStaticHeight(false);
+                        setManuallyExpanded(false);
+                    }
+                } else {
+                    setUseStaticHeight(false);
+                    // Adjust whether to collapse or expand on click based on how far the header is collapsed
+                    if (scrollValue <= scrollableDistance / 2) {
+                        staticHeaderHeight.setValue(expandedHeight);
+                    } else {
+                        staticHeaderHeight.setValue(collapsedHeight);
+                    }
+                }
+            }
+            // We have scrolled out of the dynamic range (past the point of full collapse)
+            else {
+                if (!useStaticHeight && !manuallyExpanded) {
+                    staticHeaderHeight.setValue(collapsedHeight);
+                    setUseStaticHeight(true);
+                }
+            }
+        },
+        [
+            expandedHeight,
+            collapsedHeight,
+            scrollableDistance,
+            useStaticHeight,
+            staticHeaderHeight,
+            variant,
+            searching,
+            manuallyExpanded,
+        ]
+    );
+
+    // Set up listeners
+    useEffect(() => {
+        const statics = staticHeaderHeight.addListener(onHeightChange);
+        const listen = scrollPosition.addListener(onScrollChange);
+        return (): void => {
+            scrollPosition.removeListener(listen);
+            staticHeaderHeight.removeListener(statics);
+        };
+    }, [onScrollChange, onHeightChange]);
+
+    /* STYLE FUNCTIONS */
+
+    // Returns the clamped header height based on scroll position
+    const getDynamicHeaderHeight = (): Animated.Value | Animated.AnimatedInterpolation =>
+        dynamicHeaderHeight.interpolate({
+            inputRange: [collapsedHeight, expandedHeight],
+            outputRange: [collapsedHeight, expandedHeight],
+            extrapolate: 'clamp',
+        });
+
+    const getBackgroundColor = useCallback((): string => {
+        if (searching) {
+            return theme.colors.surface;
+        }
+        // @change color once have a correct color
+        return (
+            backgroundColor ||
+            // (theme.dark ? theme.colors.actionPalette?.active || theme.colors.surface : theme.colors.primary)
+        (theme.dark ? theme.colors.surface : theme.colors.primary)
+        );
+    }, [searching, theme, backgroundColor]);
+
+    const getFontColor = useCallback((): string => {
+        if (searching) {
+          // @change color once have a correct color
+            return theme.colors.onSurface;
+        }
+        return fontColor || 'white';
+    }, [theme, fontColor, searching]);
+
+    const statusBarStyle = useCallback(
+        (): 'light-content' | 'dark-content' =>
+            color(getBackgroundColor()).isDark() ? 'light-content' : 'dark-content',
+        [getBackgroundColor]
+    );
+
+    // Returns the interpolated bottom padding of the Header text elements
+    const contentStyle = useCallback(
+        (): Array<Record<string, any>> => [
+            searching ? defaultStyles.search : defaultStyles.content,
+            searching
+                ? {}
+                : {
+                      paddingBottom: (useStaticHeight ? staticHeaderHeight : dynamicHeaderHeight).interpolate({
+                          inputRange: [collapsedHeight, expandedHeight],
+                          outputRange: [0, 28],
+                          extrapolate: 'clamp',
+                      }),
+                  },
+        ],
+        [
+            subtitle,
+            searching,
+            dynamicHeaderHeight,
+            defaultStyles,
+            useStaticHeight,
+            staticHeaderHeight,
+            collapsedHeight,
+            expandedHeight,
+        ]
+    );
+
+    /* CALLBACK FUNCTIONS */
+
+    // Callback when the Header is tapped (expandable only)
+    const onPress = useCallback((): void => {
+        if (expanded) {
+            contract.start();
+            setManuallyExpanded(false);
+            updateScrollView({
+                padding: variant === 'dynamic' ? expandedHeight : collapsedHeight,
+                animate: inDynamicRange,
+                scrollTo:
+                    variant === 'dynamic'
+                        ? inDynamicRange
+                            ? scrollableDistance
+                            : null
+                        : inDynamicRange
+                        ? 0
+                        : scrollPositionValue - scrollableDistance,
+            });
+        } else {
+            expand.start();
+            setManuallyExpanded(true);
+            updateScrollView({
+                padding: expandedHeight,
+                animate: inDynamicRange,
+                scrollTo:
+                    variant === 'dynamic'
+                        ? inDynamicRange
+                            ? 0
+                            : null
+                        : inDynamicRange
+                        ? 0
+                        : scrollPositionValue + scrollableDistance,
+            });
+        }
+    }, [
+        expanded,
+        updateScrollView,
+        collapsedHeight,
+        contract,
+        expand,
+        expandedHeight,
+        variant,
+        inDynamicRange,
+        scrollPositionValue,
+        scrollableDistance,
+    ]);
+
+    // Callback when the search bar text is updated
+    const onChangeSearchText = useCallback(
+        (text: string): void => {
+            setQuery(text);
+            if (searchableConfig && searchableConfig.onChangeText) searchableConfig.onChangeText(text);
+        },
+        [setQuery, searchableConfig]
+    );
+
+    // Callback when the search icon is clicked
+    const onPressSearch = useCallback((): void => {
+        setUseStaticHeight(true);
+        setSearching(true);
+        contract.start(() => {
+            // setSearching(true);
+        });
+        updateScrollView({
+            padding: collapsedHeight,
+            animate: expanded && inDynamicRange,
+            scrollTo: variant === 'dynamic' || expanded ? Math.max(scrollPositionValue - scrollableDistance, 0) : null,
+        });
+        setPreviousExpanded(expanded);
+    }, [
+        contract,
+        expandable,
+        inDynamicRange,
+        updateScrollView,
+        variant,
+        expanded,
+        scrollPositionValue,
+        scrollableDistance,
+        collapsedHeight,
+        staticHeaderHeightValue,
+    ]);
+
+    // Callback when the search bar content is cleared
+    const onPressSearchClear = useCallback((): void => {
+        const searchInput = searchRef.current;
+        if (searchInput) {
+            searchInput.clear();
+            if (searchableConfig && searchableConfig.onChangeText) searchableConfig.onChangeText('');
+        }
+        setQuery('');
+    }, [searchableConfig, searchRef]);
+
+    // Callback when the search bar is closed
+    const onPressSearchClose = useCallback((): void => {
+        const searchInput = searchRef.current;
+        if (searchInput) {
+            if (searchableConfig && searchableConfig.onChangeText) searchableConfig.onChangeText('');
+        }
+        setSearching(false);
+        setQuery('');
+        if (previousExpanded) {
+            expand.start();
+            updateScrollView({
+                padding: expandedHeight,
+                animate: inDynamicRange,
+                scrollTo: inDynamicRange ? 0 : scrollPositionValue + scrollableDistance,
+            });
+        } else {
+            if (variant === 'dynamic') {
+                updateScrollView({
+                    padding: expandedHeight,
+                    animate: false,
+                    scrollTo: scrollPositionValue + scrollableDistance,
+                });
+            }
+        }
+    }, [
+        searchableConfig,
+        searchRef,
+        previousExpanded,
+        expand,
+        expandedHeight,
+        inDynamicRange,
+        scrollPositionValue,
+        scrollableDistance,
+        updateScrollView,
+        variant,
+    ]);
+
+    return (
+        <>
+            <StatusBar barStyle={statusBarStyle()} translucent backgroundColor={'transparent'} />
+            <TouchableWithoutFeedback
+                accessible={false}
+                onPress={(): void => onPress()}
+                disabled={!expandable || searching}
+                {...viewProps}
+            >
+                <AnimatedSafeAreaView
+                    style={[
+                        defaultStyles.root,
+                        styles.root,
+                        style,
+                        /* We only use the dynamic height when we are in the dynamic range (from scrollPosition zero to expandedHeight - collapsedHeight)
+                            Everywhere else, we use the fixed header height
+                            */
+                        { height: useStaticHeight ? staticHeaderHeight : getDynamicHeaderHeight() },
+                        searching ? { backgroundColor: theme.colors.surface } : {},
+                    ]}
+                >
+                    <SearchContext.Provider
+                        value={{
+                            searchRef: searchRef,
+                            query: query,
+                            searching: searching,
+                            onQueryChange: onChangeSearchText,
+                            searchConfig: searchableConfig,
+                            onSearch: onPressSearch,
+                            onClear: onPressSearchClear,
+                            onClose: onPressSearchClose,
+                        }}
+                    >
+                        <ColorContext.Provider value={{ color: getFontColor() }}>
+                            <HeaderHeightContext.Provider
+                                value={{
+                                    headerHeight: useStaticHeight ? staticHeaderHeight : getDynamicHeaderHeight(),
+                                }}
+                            >
+                                <HeaderBackgroundImage
+                                    backgroundImage={backgroundImage}
+                                    style={styles.backgroundImage}
+                                />
+                                <Animated.View style={[contentStyle(), styles.content]}>
+                                    <HeaderNavigationIcon icon={icon} onPress={onIconPress} style={styles.icon} />
+                                    <HeaderContent
+                                        theme={theme}
+                                        title={title}
+                                        subtitle={subtitle}
+                                        info={info}
+                                        actions={getActionItemInfo()}
+                                        styles={{
+                                            root: styles.textContent,
+                                            title: styles.title,
+                                            subtitle: styles.subtitle,
+                                            info: styles.info,
+                                            search: styles.search,
+                                        }}
+                                        washingtonStyle={washingtonStyle}
+                                    />
+                                    <HeaderActionItems
+                                        actionItems={actionItems}
+                                        styles={{
+                                            root: styles.actionPanel,
+                                            actionItem: styles.actionItem,
+                                            component: styles.component,
+                                        }}
+                                    />
+                                </Animated.View>
+                                {props.children}
+                            </HeaderHeightContext.Provider>
+                        </ColorContext.Provider>
+                    </SearchContext.Provider>
+                </AnimatedSafeAreaView>
+            </TouchableWithoutFeedback>
+        </>
+    );
+
+};
+Header.displayName = 'Header';

--- a/components/src/md3/Header/Header.tsx
+++ b/components/src/md3/Header/Header.tsx
@@ -40,8 +40,7 @@ const headerStyles = (
     root: ViewStyle;
     content: ViewStyle;
     search: ViewStyle;
-}> => {
-    return {
+}> => ({
         root: {
             width: '100%',
             backgroundColor:
@@ -71,8 +70,7 @@ const headerStyles = (
             alignItems: 'center',
             paddingHorizontal: 16,
         },
-    };
-};
+    });
 
 export type SearchableConfig = {
     /**
@@ -218,8 +216,6 @@ export type HeaderProps = ViewProps & {
      * Default: static
      */
     variant?: 'dynamic' | 'static';
-
-
 };
 
 export const Header: React.FC<HeaderProps> = (props) => {

--- a/components/src/md3/Header/Header.tsx
+++ b/components/src/md3/Header/Header.tsx
@@ -219,12 +219,7 @@ export type HeaderProps = ViewProps & {
      */
     variant?: 'dynamic' | 'static';
 
-    /**
-     * @experimental
-     *
-     * Set to true to use the alternative subtitle styling (larger size, light weight)
-     */
-    washingtonStyle?: boolean;
+
 };
 
 export const Header: React.FC<HeaderProps> = (props) => {
@@ -248,7 +243,6 @@ export const Header: React.FC<HeaderProps> = (props) => {
         theme: themeOverride,
         title,
         variant = 'static',
-        washingtonStyle,
         updateScrollView = (): void => {},
         ...viewProps
     } = props;
@@ -736,7 +730,6 @@ export const Header: React.FC<HeaderProps> = (props) => {
                                             info: styles.info,
                                             search: styles.search,
                                         }}
-                                        washingtonStyle={washingtonStyle}
                                     />
                                     <HeaderActionItems
                                         actionItems={actionItems}

--- a/components/src/md3/Header/Header.tsx
+++ b/components/src/md3/Header/Header.tsx
@@ -41,36 +41,36 @@ const headerStyles = (
     content: ViewStyle;
     search: ViewStyle;
 }> => ({
-        root: {
-            width: '100%',
-            backgroundColor:
-                props.backgroundColor ||
-                // @change color once have a correct color
-                // (theme.dark ? theme.colors.actionPalette?.active || theme.colors.surface : theme.colors.primary),
-                (theme.dark ? theme.colors.surface : theme.colors.primary),
-            shadowColor: 'rgba(0, 0, 0, 0.3)',
-            shadowOffset: {
-                width: 0,
-                height: 1,
-            },
-            shadowRadius: 2,
-            shadowOpacity: 1,
-            elevation: 0,
-            paddingTop: Platform.OS === 'android' ? StatusBar.currentHeight : 0,
+    root: {
+        width: '100%',
+        backgroundColor:
+            props.backgroundColor ||
+            // @change color once have a correct color
+            // (theme.dark ? theme.colors.actionPalette?.active || theme.colors.surface : theme.colors.primary),
+            (theme.dark ? theme.colors.surface : theme.colors.primary),
+        shadowColor: 'rgba(0, 0, 0, 0.3)',
+        shadowOffset: {
+            width: 0,
+            height: 1,
         },
-        content: {
-            flex: 1,
-            paddingHorizontal: 16,
-            flexDirection: 'row',
-            minHeight: 56 * fontScale,
-        },
-        search: {
-            flex: 1,
-            flexDirection: 'row',
-            alignItems: 'center',
-            paddingHorizontal: 16,
-        },
-    });
+        shadowRadius: 2,
+        shadowOpacity: 1,
+        elevation: 0,
+        paddingTop: Platform.OS === 'android' ? StatusBar.currentHeight : 0,
+    },
+    content: {
+        flex: 1,
+        paddingHorizontal: 16,
+        flexDirection: 'row',
+        minHeight: 56 * fontScale,
+    },
+    search: {
+        flex: 1,
+        flexDirection: 'row',
+        alignItems: 'center',
+        paddingHorizontal: 16,
+    },
+});
 
 export type SearchableConfig = {
     /**

--- a/components/src/md3/Header/constants.ts
+++ b/components/src/md3/Header/constants.ts
@@ -1,0 +1,3 @@
+export const ICON_SIZE = 24;
+export const ICON_SPACING = 16;
+export const ANIMATION_LENGTH = 300;

--- a/components/src/md3/Header/contexts/ColorContextProvider.tsx
+++ b/components/src/md3/Header/contexts/ColorContextProvider.tsx
@@ -1,0 +1,23 @@
+import { createContext, useContext } from 'react';
+
+type ColorContextType = {
+    color: string;
+};
+
+export const ColorContext = createContext<ColorContextType | null>(null);
+
+/**
+ * useColor hook
+ *
+ * This hook will provide you with the current text color value that is set at the top level
+ * of the Header component. We expose this through a Context in order to avoid passing this prop
+ * through every layer of the component hierarchy. This hook can only be called from within a
+ * ColorContext.Provider.
+ */
+export const useColor = (): ColorContextType => {
+    const context = useContext(ColorContext);
+    if (context === null) {
+        throw new Error('useColor must be used within a ColorContextProvider');
+    }
+    return context;
+};

--- a/components/src/md3/Header/contexts/HeaderHeightContextProvider.tsx
+++ b/components/src/md3/Header/contexts/HeaderHeightContextProvider.tsx
@@ -1,0 +1,23 @@
+import { createContext, useContext } from 'react';
+import { Animated } from 'react-native';
+
+type HeaderHeightContextType = {
+    headerHeight: Animated.Value | Animated.AnimatedInterpolation;
+};
+
+export const HeaderHeightContext = createContext<HeaderHeightContextType | null>(null);
+
+/**
+ * useHeaderHeight hook
+ *
+ * This hook will provide you with the current height of the Header component. We expose this through a Context in order to avoid passing this prop
+ * through every layer of the component hierarchy. This hook can only be called from within a
+ * HeaderHeightContext.Provider.
+ */
+export const useHeaderHeight = (): HeaderHeightContextType => {
+    const context = useContext(HeaderHeightContext);
+    if (context === null) {
+        throw new Error('useHeaderHeight must be used within a HeaderHeightContextProvider');
+    }
+    return context;
+};

--- a/components/src/md3/Header/contexts/SearchContextProvider.tsx
+++ b/components/src/md3/Header/contexts/SearchContextProvider.tsx
@@ -1,0 +1,32 @@
+import { Ref, createContext, useContext } from 'react';
+import { SearchableConfig } from '../Header';
+import { TextInput } from 'react-native';
+
+type SearchContextType = {
+    searchRef: Ref<TextInput>;
+    query: string;
+    searching: boolean;
+    onQueryChange: (text: string) => void;
+    searchConfig?: SearchableConfig;
+    onSearch: () => void;
+    onClear: () => void;
+    onClose: () => void;
+};
+
+export const SearchContext = createContext<SearchContextType | null>(null);
+
+/**
+ * useSearch hook
+ *
+ * This hook will provide you with the current searchConfig that is set at the top level
+ * of the Header component. We expose this through a Context in order to avoid passing this prop
+ * through every layer of the component hierarchy. This hook can only be called from within a
+ * SearchContext.Provider.
+ */
+export const useSearch = (): SearchContextType => {
+    const context = useContext(SearchContext);
+    if (context === null) {
+        throw new Error('useSearch must be used within a SearchContextProvider');
+    }
+    return context;
+};

--- a/components/src/md3/Header/headerActionItems.tsx
+++ b/components/src/md3/Header/headerActionItems.tsx
@@ -1,0 +1,124 @@
+import React from 'react';
+import { StyleSheet, TouchableOpacity, View, StyleProp, ViewStyle } from 'react-native';
+import { HeaderIcon } from './headerIcon';
+import { useSearch } from './contexts/SearchContextProvider';
+import { HeaderActionComponent, HeaderIcon as HeaderIconType, IconFamily } from '../__types__';
+import { useFontScale } from '../__contexts__/font-scale-context';
+
+const ClearIcon: IconFamily = { name: 'clear' };
+const SearchIcon: IconFamily = { name: 'search' };
+
+const makeStyles = (
+    fontScale: number
+): StyleSheet.NamedStyles<{
+    root: ViewStyle;
+    actionItem: ViewStyle;
+    component: ViewStyle;
+}> =>
+    StyleSheet.create({
+        root: {
+            flexDirection: 'row',
+            alignItems: 'center',
+            position: 'absolute',
+            right: 8,
+            height: 56 * fontScale,
+        },
+        actionItem: {
+            height: 40 * fontScale,
+            width: 24 * fontScale + 16,
+            paddingVertical: 8 * fontScale,
+            paddingHorizontal: 8,
+        },
+        component: {
+            height: 40 * fontScale,
+            width: 40 * fontScale,
+            justifyContent: 'center',
+        },
+    });
+
+type ActionItemProps = {
+    /** Array of up to three action items on the right of the header */
+    actionItems?: Array<HeaderIconType | HeaderActionComponent>;
+
+    /** Style overrides for internal elements. The styles you provide will be combined with the default styles. */
+    styles?: {
+        root?: StyleProp<ViewStyle>;
+        actionItem?: StyleProp<ViewStyle>;
+        component?: StyleProp<ViewStyle>;
+    };
+};
+
+/**
+ * HeaderActionItems component
+ *
+ * The HeaderActionItems is a helper component for organizing the contents in the Header. It is
+ * used for displaying all of the action item icons and components.
+ */
+export const HeaderActionItems: React.FC<ActionItemProps> = (props) => {
+    const { actionItems, styles = {} } = props;
+    const { searchConfig, searching, query, onClear, onSearch } = useSearch();
+    const fontScale = useFontScale();
+    const defaultStyles = makeStyles(fontScale);
+
+    let items: Array<HeaderIconType | HeaderActionComponent> = actionItems || [];
+
+    if (searching) {
+        if (query) {
+            items = [
+                {
+                    icon: ClearIcon,
+                    onPress: onClear,
+                },
+            ];
+        } else {
+            items = [];
+        }
+    } else if (searchConfig) {
+        items = [
+            {
+                icon: SearchIcon,
+                onPress: onSearch,
+            },
+        ];
+        if (actionItems) {
+            items = items.concat(actionItems);
+        }
+    }
+
+    if (items) {
+        return (
+            <View style={[defaultStyles.root, styles.root]}>
+                {items.map((actionItem: HeaderIconType | HeaderActionComponent, index) => {
+                    if ('component' in actionItem) {
+                        return (
+                            <View
+                                key={`action_${index}`}
+                                testID={`header-action-item${index}`}
+                                accessibilityLabel={`header-action-item${index}`}
+                                style={[
+                                    defaultStyles.component,
+                                    actionItem.width ? { width: actionItem.width } : {},
+                                    styles.component,
+                                ]}
+                            >
+                                {actionItem.component}
+                            </View>
+                        );
+                    }
+                    return (
+                        <TouchableOpacity
+                            key={`action_${index}`}
+                            testID={`header-action-item${index}`}
+                            accessibilityLabel={`header-action-item${index}`}
+                            onPress={actionItem.onPress}
+                            style={[defaultStyles.actionItem, styles.actionItem]}
+                        >
+                            <HeaderIcon icon={actionItem.icon} />
+                        </TouchableOpacity>
+                    );
+                })}
+            </View>
+        );
+    }
+    return null;
+};

--- a/components/src/md3/Header/headerBackgroundImage.tsx
+++ b/components/src/md3/Header/headerBackgroundImage.tsx
@@ -1,0 +1,64 @@
+import React from 'react';
+import { Animated, Dimensions, ImageProps, ImageSourcePropType, ImageStyle, StyleSheet } from 'react-native';
+import { useSearch } from './contexts/SearchContextProvider';
+import { useHeaderHeight } from './contexts/HeaderHeightContextProvider';
+import { useHeaderDimensions } from '../__hooks__/useHeaderDimensions';
+
+type HeaderBackgroundImageStyles = {
+    root: ImageStyle;
+};
+
+const defaultStyles = (deviceWidth: number): HeaderBackgroundImageStyles =>
+    StyleSheet.create({
+        root: {
+            position: 'absolute',
+            top: 0,
+            left: 0,
+            right: 0,
+            bottom: 0,
+            resizeMode: 'cover',
+            width: deviceWidth,
+        },
+    });
+type HeaderBackgroundProps = Omit<ImageProps, 'source'> & {
+    /** Background image to render */
+    backgroundImage?: ImageSourcePropType;
+};
+
+/**
+ * HeaderBackgroundImage component
+ *
+ * The HeaderBackgroundImage is a helper component for organizing the contents in the Header. It is
+ * used for displaying the background image and blending it with the background color.
+ */
+export const HeaderBackgroundImage: React.FC<HeaderBackgroundProps> = (props) => {
+    const { backgroundImage, style, ...otherImageProps } = props;
+    const { searching } = useSearch();
+    const { headerHeight } = useHeaderHeight();
+    const { width } = Dimensions.get('screen');
+
+    const { REGULAR_HEIGHT, EXTENDED_HEIGHT } = useHeaderDimensions();
+
+    if (backgroundImage && !searching) {
+        return (
+            <Animated.Image
+                testID={'header-background-image'}
+                resizeMethod={'resize'}
+                {...otherImageProps}
+                source={backgroundImage}
+                style={[
+                    defaultStyles(width).root,
+                    style,
+                    {
+                        height: headerHeight,
+                        opacity: headerHeight.interpolate({
+                            inputRange: [REGULAR_HEIGHT, EXTENDED_HEIGHT],
+                            outputRange: [0.2, 0.3],
+                        }),
+                    },
+                ]}
+            />
+        );
+    }
+    return null;
+};

--- a/components/src/md3/Header/headerContent.tsx
+++ b/components/src/md3/Header/headerContent.tsx
@@ -106,12 +106,6 @@ type HeaderSubtitleProps = {
     /** Style to apply to the Text element */
     style?: StyleProp<TextStyle>;
 
-    /**
-     * @experimental
-     *
-     * Set to true to use the alternative subtitle styling (larger size, light weight)
-     */
-    washingtonStyle?: boolean;
 };
 /**
  * HeaderSubtitle component
@@ -120,19 +114,19 @@ type HeaderSubtitleProps = {
  * used for displaying and resizing the subtitle text.
  */
 const HeaderSubtitle: React.FC<HeaderSubtitleProps> = (props) => {
-    const { subtitle, theme, style, washingtonStyle } = props;
+    const { subtitle, theme, style } = props;
     const { color: textColor } = useColor();
     const { maxScale, disableScaling } = useFontScaleSettings();
 
     const getSubtitleStyle = useCallback(
         () => ({
             color: textColor,
-            fontFamily: washingtonStyle ? theme.fonts.titleSmall : theme.fonts.titleMedium,
-            fontSize: washingtonStyle ? 18 : 16,
+            fontFamily: 'OpenSans-Regular',
+            // fontFamily: theme.fonts.titleMedium,
             writingDirection: I18nManager.isRTL ? 'rtl' : ('ltr' as WritingDirection),
             textAlign: Platform.OS === 'android' ? 'left' : ('auto' as TextAlign),
         }),
-        [textColor, theme, washingtonStyle]
+        [textColor, theme]
     );
 
     if (subtitle) {
@@ -193,7 +187,8 @@ const HeaderInfo: React.FC<HeaderInfoProps> = (props) => {
                 outputRange: [0, 1],
                 extrapolate: 'clamp',
             }),
-            fontFamily: theme.fonts.bodyMedium,
+            fontFamily: 'OpenSans-Regular',
+            // fontFamily: theme.fonts.bodyMedium,
             fontSize: headerHeight.interpolate({
                 inputRange: [REGULAR_HEIGHT, EXTENDED_HEIGHT],
                 outputRange: [0.1, 20],
@@ -310,12 +305,6 @@ export type HeaderContentProps = {
      */
     theme: MD3Theme;
 
-    /**
-     * @experimental
-     *
-     * Set to true to use the alternative subtitle styling (larger size, light weight)
-     */
-    washingtonStyle?: boolean;
 };
 
 /**
@@ -332,7 +321,6 @@ export const HeaderContent: React.FC<HeaderContentProps> = (props) => {
         actions = { components: { count: 0, width: 0 }, icons: { count: 0 } },
         theme,
         styles = {},
-        washingtonStyle,
     } = props;
     const { headerHeight } = useHeaderHeight();
     const { searching, searchConfig } = useSearch();
@@ -354,7 +342,6 @@ export const HeaderContent: React.FC<HeaderContentProps> = (props) => {
                 key="subtitle_key"
                 theme={theme}
                 style={[styles.subtitle]}
-                washingtonStyle={washingtonStyle}
             />,
         ];
     }

--- a/components/src/md3/Header/headerContent.tsx
+++ b/components/src/md3/Header/headerContent.tsx
@@ -116,11 +116,18 @@ const HeaderSubtitle: React.FC<HeaderSubtitleProps> = (props) => {
     const { subtitle, theme, style } = props;
     const { color: textColor } = useColor();
     const { maxScale, disableScaling } = useFontScaleSettings();
+    const { headerHeight } = useHeaderHeight();
+    const { REGULAR_HEIGHT, EXTENDED_HEIGHT } = useHeaderDimensions();
 
     const getSubtitleStyle = useCallback(
         () => ({
             color: textColor,
             fontFamily: 'OpenSans-Regular',
+            fontSize: headerHeight.interpolate({
+                inputRange: [REGULAR_HEIGHT, EXTENDED_HEIGHT],
+                outputRange: [14, 16],
+                extrapolate: 'clamp',
+            }),
             // fontFamily: theme.fonts.titleMedium,
             writingDirection: I18nManager.isRTL ? 'rtl' : ('ltr' as WritingDirection),
             textAlign: Platform.OS === 'android' ? 'left' : ('auto' as TextAlign),
@@ -190,7 +197,7 @@ const HeaderInfo: React.FC<HeaderInfoProps> = (props) => {
             // fontFamily: theme.fonts.bodyMedium,
             fontSize: headerHeight.interpolate({
                 inputRange: [REGULAR_HEIGHT, EXTENDED_HEIGHT],
-                outputRange: [0.1, 20],
+                outputRange: [0.1, 14],
                 extrapolate: 'clamp',
             }),
             writingDirection: I18nManager.isRTL ? 'rtl' : ('ltr' as WritingDirection),
@@ -334,8 +341,8 @@ export const HeaderContent: React.FC<HeaderContentProps> = (props) => {
     } else {
         content = [
             <HeaderTitle title={title} key="title_key" theme={theme} style={[styles.title]} />,
-            <HeaderInfo info={info} key="info_key" theme={theme} style={[styles.info]} />,
             <HeaderSubtitle subtitle={subtitle} key="subtitle_key" theme={theme} style={[styles.subtitle]} />,
+            <HeaderInfo info={info} key="info_key" theme={theme} style={[styles.info]} />,
         ];
     }
 

--- a/components/src/md3/Header/headerContent.tsx
+++ b/components/src/md3/Header/headerContent.tsx
@@ -66,7 +66,6 @@ const HeaderTitle: React.FC<HeaderTitleProps> = (props) => {
         () => ({
             color: textColor,
             fontFamily: 'OpenSans-Semibold',
-            // fontFamily: theme.fonts.headlineMedium,
             fontSize: headerHeight.interpolate({
                 inputRange: [REGULAR_HEIGHT, EXTENDED_HEIGHT],
                 outputRange: [20, 30],
@@ -128,7 +127,6 @@ const HeaderSubtitle: React.FC<HeaderSubtitleProps> = (props) => {
                 outputRange: [14, 16],
                 extrapolate: 'clamp',
             }),
-            // fontFamily: theme.fonts.titleMedium,
             writingDirection: I18nManager.isRTL ? 'rtl' : ('ltr' as WritingDirection),
             textAlign: Platform.OS === 'android' ? 'left' : ('auto' as TextAlign),
         }),
@@ -194,7 +192,6 @@ const HeaderInfo: React.FC<HeaderInfoProps> = (props) => {
                 extrapolate: 'clamp',
             }),
             fontFamily: 'OpenSans-Regular',
-            // fontFamily: theme.fonts.bodyMedium,
             fontSize: headerHeight.interpolate({
                 inputRange: [REGULAR_HEIGHT, EXTENDED_HEIGHT],
                 outputRange: [0.1, 14],

--- a/components/src/md3/Header/headerContent.tsx
+++ b/components/src/md3/Header/headerContent.tsx
@@ -17,6 +17,7 @@ import { useColor } from './contexts/ColorContextProvider';
 import { useHeaderHeight } from './contexts/HeaderHeightContextProvider';
 import { useHeaderDimensions } from '../__hooks__/useHeaderDimensions';
 import { useFontScale, useFontScaleSettings } from '../__contexts__/font-scale-context';
+import { MD3Theme } from 'react-native-paper';
 
 const headerContentStyles = StyleSheet.create({
     titleContainer: {
@@ -43,7 +44,7 @@ type HeaderTitleProps = {
     /**
      * Theme value overrides specific to this component.
      */
-    theme: ReactNativePaper.Theme;
+    theme: MD3Theme;
 
     /** Style to apply to the Text element */
     style?: StyleProp<TextStyle>;
@@ -64,7 +65,8 @@ const HeaderTitle: React.FC<HeaderTitleProps> = (props) => {
     const getTitleStyle = useCallback(
         () => ({
             color: textColor,
-            fontFamily: theme.fonts.medium.fontFamily,
+            fontFamily: 'OpenSans-Semibold',
+            // fontFamily: theme.fonts.headlineMedium,
             fontSize: headerHeight.interpolate({
                 inputRange: [REGULAR_HEIGHT, EXTENDED_HEIGHT],
                 outputRange: [20, 30],
@@ -99,7 +101,7 @@ type HeaderSubtitleProps = {
     /**
      * Theme value overrides specific to this component.
      */
-    theme: ReactNativePaper.Theme;
+    theme: MD3Theme;
 
     /** Style to apply to the Text element */
     style?: StyleProp<TextStyle>;
@@ -125,7 +127,7 @@ const HeaderSubtitle: React.FC<HeaderSubtitleProps> = (props) => {
     const getSubtitleStyle = useCallback(
         () => ({
             color: textColor,
-            fontFamily: washingtonStyle ? theme.fonts.light.fontFamily : theme.fonts.regular.fontFamily,
+            fontFamily: washingtonStyle ? theme.fonts.titleSmall : theme.fonts.titleMedium,
             fontSize: washingtonStyle ? 18 : 16,
             writingDirection: I18nManager.isRTL ? 'rtl' : ('ltr' as WritingDirection),
             textAlign: Platform.OS === 'android' ? 'left' : ('auto' as TextAlign),
@@ -159,7 +161,7 @@ type HeaderInfoProps = {
     /**
      * Theme value overrides specific to this component.
      */
-    theme: ReactNativePaper.Theme;
+    theme: MD3Theme;
 
     /** Style to apply to the Text element */
     style?: StyleProp<TextStyle>;
@@ -191,7 +193,7 @@ const HeaderInfo: React.FC<HeaderInfoProps> = (props) => {
                 outputRange: [0, 1],
                 extrapolate: 'clamp',
             }),
-            fontFamily: theme.fonts.regular.fontFamily,
+            fontFamily: theme.fonts.bodyMedium,
             fontSize: headerHeight.interpolate({
                 inputRange: [REGULAR_HEIGHT, EXTENDED_HEIGHT],
                 outputRange: [0.1, 20],
@@ -226,7 +228,7 @@ type SearchContentProps = {
     /**
      * Theme value overrides specific to this component.
      */
-    theme: ReactNativePaper.Theme;
+    theme: MD3Theme;
 
     /** Style to apply to the Text element */
     style?: StyleProp<TextStyle>;
@@ -253,8 +255,7 @@ const SearchContent: React.FC<SearchContentProps> = (props) => {
                 {
                     padding: 0,
                     color: textColor,
-                    fontSize: 20,
-                    ...theme.fonts.light,
+                    ...theme.fonts.titleMedium,
                 },
                 style,
             ]}
@@ -307,7 +308,7 @@ export type HeaderContentProps = {
     /**
      * Theme value overrides specific to this component.
      */
-    theme: ReactNativePaper.Theme;
+    theme: MD3Theme;
 
     /**
      * @experimental

--- a/components/src/md3/Header/headerContent.tsx
+++ b/components/src/md3/Header/headerContent.tsx
@@ -1,0 +1,393 @@
+import React, { useCallback } from 'react';
+import {
+    Animated,
+    StyleSheet,
+    TextInput,
+    View,
+    StyleProp,
+    ViewStyle,
+    TextStyle,
+    I18nManager,
+    Platform,
+} from 'react-native';
+import color from 'color';
+import { ICON_SIZE, ICON_SPACING } from './constants';
+import { useSearch } from './contexts/SearchContextProvider';
+import { useColor } from './contexts/ColorContextProvider';
+import { useHeaderHeight } from './contexts/HeaderHeightContextProvider';
+import { useHeaderDimensions } from '../__hooks__/useHeaderDimensions';
+import { useFontScale, useFontScaleSettings } from '../__contexts__/font-scale-context';
+
+const headerContentStyles = StyleSheet.create({
+    titleContainer: {
+        flex: 1,
+        flexDirection: 'column',
+        justifyContent: 'flex-end',
+    },
+    searchContainer: {
+        flex: 1,
+        flexDirection: 'column',
+        justifyContent: 'center',
+        marginRight: 56,
+        marginTop: 0,
+    },
+});
+
+type WritingDirection = 'ltr' | 'rtl';
+type TextAlign = 'left' | 'right' | 'center' | 'auto';
+
+type HeaderTitleProps = {
+    /** The content to render for the title */
+    title: React.ReactNode;
+
+    /**
+     * Theme value overrides specific to this component.
+     */
+    theme: ReactNativePaper.Theme;
+
+    /** Style to apply to the Text element */
+    style?: StyleProp<TextStyle>;
+};
+
+/**
+ * HeaderTitle component
+ *
+ * The HeaderTitle is a helper component for organizing the contents in the Header. It is
+ * used for displaying and resizing the title text.
+ */
+const HeaderTitle: React.FC<HeaderTitleProps> = (props) => {
+    const { title, theme, style } = props;
+    const { color: textColor } = useColor();
+    const { headerHeight } = useHeaderHeight();
+    const { REGULAR_HEIGHT, EXTENDED_HEIGHT } = useHeaderDimensions();
+    const { maxScale, disableScaling } = useFontScaleSettings();
+    const getTitleStyle = useCallback(
+        () => ({
+            color: textColor,
+            fontFamily: theme.fonts.medium.fontFamily,
+            fontSize: headerHeight.interpolate({
+                inputRange: [REGULAR_HEIGHT, EXTENDED_HEIGHT],
+                outputRange: [20, 30],
+                extrapolate: 'clamp',
+            }),
+            writingDirection: I18nManager.isRTL ? 'rtl' : ('ltr' as WritingDirection),
+            textAlign: Platform.OS === 'android' ? 'left' : ('auto' as TextAlign),
+        }),
+        [textColor, headerHeight, theme, REGULAR_HEIGHT, EXTENDED_HEIGHT]
+    );
+
+    return typeof title === 'string' ? (
+        <Animated.Text
+            testID={'header-title'}
+            style={[getTitleStyle(), style]}
+            numberOfLines={1}
+            ellipsizeMode={'tail'}
+            allowFontScaling={!disableScaling}
+            maxFontSizeMultiplier={maxScale}
+        >
+            {title}
+        </Animated.Text>
+    ) : (
+        <>{title}</>
+    );
+};
+
+type HeaderSubtitleProps = {
+    /** The content to render for the subtitle */
+    subtitle?: React.ReactNode;
+
+    /**
+     * Theme value overrides specific to this component.
+     */
+    theme: ReactNativePaper.Theme;
+
+    /** Style to apply to the Text element */
+    style?: StyleProp<TextStyle>;
+
+    /**
+     * @experimental
+     *
+     * Set to true to use the alternative subtitle styling (larger size, light weight)
+     */
+    washingtonStyle?: boolean;
+};
+/**
+ * HeaderSubtitle component
+ *
+ * The HeaderSubtitle is a helper component for organizing the contents in the Header. It is
+ * used for displaying and resizing the subtitle text.
+ */
+const HeaderSubtitle: React.FC<HeaderSubtitleProps> = (props) => {
+    const { subtitle, theme, style, washingtonStyle } = props;
+    const { color: textColor } = useColor();
+    const { maxScale, disableScaling } = useFontScaleSettings();
+
+    const getSubtitleStyle = useCallback(
+        () => ({
+            color: textColor,
+            fontFamily: washingtonStyle ? theme.fonts.light.fontFamily : theme.fonts.regular.fontFamily,
+            fontSize: washingtonStyle ? 18 : 16,
+            writingDirection: I18nManager.isRTL ? 'rtl' : ('ltr' as WritingDirection),
+            textAlign: Platform.OS === 'android' ? 'left' : ('auto' as TextAlign),
+        }),
+        [textColor, theme, washingtonStyle]
+    );
+
+    if (subtitle) {
+        return typeof subtitle === 'string' ? (
+            <Animated.Text
+                testID={'header-subtitle'}
+                style={[getSubtitleStyle(), style]}
+                numberOfLines={1}
+                ellipsizeMode={'tail'}
+                allowFontScaling={!disableScaling}
+                maxFontSizeMultiplier={maxScale}
+            >
+                {subtitle}
+            </Animated.Text>
+        ) : (
+            <>{subtitle}</>
+        );
+    }
+    return null;
+};
+
+type HeaderInfoProps = {
+    /** The content to render for the info */
+    info?: React.ReactNode;
+
+    /**
+     * Theme value overrides specific to this component.
+     */
+    theme: ReactNativePaper.Theme;
+
+    /** Style to apply to the Text element */
+    style?: StyleProp<TextStyle>;
+};
+/**
+ * HeaderInfo component
+ *
+ * The HeaderInfo is a helper component for organizing the contents in the Header. It is
+ * used for displaying and resizing the info text.
+ */
+const HeaderInfo: React.FC<HeaderInfoProps> = (props) => {
+    const { info, theme, style } = props;
+    const { color: textColor } = useColor();
+    const { headerHeight } = useHeaderHeight();
+    const { maxScale, disableScaling } = useFontScaleSettings();
+    const fontScale = useFontScale();
+    const { REGULAR_HEIGHT, EXTENDED_HEIGHT } = useHeaderDimensions();
+
+    const getInfoStyle = useCallback(
+        () => ({
+            color: textColor,
+            marginTop: headerHeight.interpolate({
+                inputRange: [REGULAR_HEIGHT, EXTENDED_HEIGHT],
+                outputRange: [-2 * fontScale, 0],
+                extrapolate: 'clamp',
+            }),
+            opacity: headerHeight.interpolate({
+                inputRange: [REGULAR_HEIGHT, EXTENDED_HEIGHT],
+                outputRange: [0, 1],
+                extrapolate: 'clamp',
+            }),
+            fontFamily: theme.fonts.regular.fontFamily,
+            fontSize: headerHeight.interpolate({
+                inputRange: [REGULAR_HEIGHT, EXTENDED_HEIGHT],
+                outputRange: [0.1, 20],
+                extrapolate: 'clamp',
+            }),
+            writingDirection: I18nManager.isRTL ? 'rtl' : ('ltr' as WritingDirection),
+            textAlign: Platform.OS === 'android' ? 'left' : ('auto' as TextAlign),
+        }),
+        [textColor, theme, headerHeight, REGULAR_HEIGHT, EXTENDED_HEIGHT, fontScale]
+    );
+
+    if (info) {
+        return typeof info === 'string' ? (
+            <Animated.Text
+                testID={'header-info'}
+                style={[getInfoStyle(), style]}
+                numberOfLines={1}
+                ellipsizeMode={'tail'}
+                allowFontScaling={!disableScaling}
+                maxFontSizeMultiplier={maxScale}
+            >
+                {info}
+            </Animated.Text>
+        ) : (
+            <>{info}</>
+        );
+    }
+    return null;
+};
+
+type SearchContentProps = {
+    /**
+     * Theme value overrides specific to this component.
+     */
+    theme: ReactNativePaper.Theme;
+
+    /** Style to apply to the Text element */
+    style?: StyleProp<TextStyle>;
+};
+/**
+ * SearchContent component
+ *
+ * The SearchContent is a helper component for organizing the contents in the Header. It is
+ * used for displaying and styling the search input. It retrieves the search configuration via
+ * the useSearch hook.
+ */
+const SearchContent: React.FC<SearchContentProps> = (props) => {
+    const { theme, style } = props;
+    const { searchConfig = {}, onQueryChange, searchRef } = useSearch();
+    const { color: textColor } = useColor();
+    const { maxScale, disableScaling } = useFontScaleSettings();
+    const placeholderTextColor = color(textColor).fade(0.4).string();
+
+    return (
+        <TextInput
+            key={'search-input'}
+            ref={searchRef}
+            style={[
+                {
+                    padding: 0,
+                    color: textColor,
+                    fontSize: 20,
+                    ...theme.fonts.light,
+                },
+                style,
+            ]}
+            autoCapitalize={searchConfig.autoCapitalize || 'none'}
+            autoCorrect={searchConfig.autoCorrect || false}
+            autoFocus={searchConfig.autoFocus}
+            numberOfLines={1}
+            onChangeText={onQueryChange}
+            placeholder={searchConfig.placeholder || 'Search'}
+            placeholderTextColor={placeholderTextColor}
+            returnKeyType={'search'}
+            selectionColor={placeholderTextColor}
+            underlineColorAndroid={'transparent'}
+            allowFontScaling={!disableScaling}
+            maxFontSizeMultiplier={maxScale}
+        />
+    );
+};
+
+export type HeaderContentProps = {
+    /** The content to render for the title */
+    title: React.ReactNode;
+
+    /** The content to render for the subtitle */
+    subtitle?: React.ReactNode;
+
+    /** The content to render for the info */
+    info?: React.ReactNode;
+
+    /** Specifies the number of avatars and icons that are included in the action list */
+    actions?: {
+        components: {
+            count: number;
+            width: number;
+        };
+        icons: {
+            count: number;
+        };
+    };
+
+    /** Style overrides for internal elements. The styles you provide will be combined with the default styles. */
+    styles?: {
+        root?: StyleProp<ViewStyle>;
+        title?: StyleProp<TextStyle>;
+        subtitle?: StyleProp<TextStyle>;
+        info?: StyleProp<TextStyle>;
+        search?: StyleProp<TextStyle>;
+    };
+
+    /**
+     * Theme value overrides specific to this component.
+     */
+    theme: ReactNativePaper.Theme;
+
+    /**
+     * @experimental
+     *
+     * Set to true to use the alternative subtitle styling (larger size, light weight)
+     */
+    washingtonStyle?: boolean;
+};
+
+/**
+ * HeaderContent component
+ *
+ * The HeaderContent is a helper component for organizing the contents in the Header. It is
+ * a wrapper that organizes the title, subtitle, info, and search inputs appropriately.
+ */
+export const HeaderContent: React.FC<HeaderContentProps> = (props) => {
+    const {
+        title,
+        subtitle,
+        info,
+        actions = { components: { count: 0, width: 0 }, icons: { count: 0 } },
+        theme,
+        styles = {},
+        washingtonStyle,
+    } = props;
+    const { headerHeight } = useHeaderHeight();
+    const { searching, searchConfig } = useSearch();
+    const fontScale = useFontScale();
+    const defaultStyles = headerContentStyles;
+
+    const { REGULAR_HEIGHT, EXTENDED_HEIGHT } = useHeaderDimensions();
+
+    let content: JSX.Element[] = [];
+
+    if (searchConfig && searching) {
+        content = [<SearchContent key={'search-content'} theme={theme} style={styles.search} />];
+    } else {
+        content = [
+            <HeaderTitle title={title} key="title_key" theme={theme} style={[styles.title]} />,
+            <HeaderInfo info={info} key="info_key" theme={theme} style={[styles.info]} />,
+            <HeaderSubtitle
+                subtitle={subtitle}
+                key="subtitle_key"
+                theme={theme}
+                style={[styles.subtitle]}
+                washingtonStyle={washingtonStyle}
+            />,
+        ];
+    }
+
+    const getActionPanelWidth = useCallback(() => {
+        let iconLength = actions.icons.count;
+        const componentsLength = actions.components.count;
+        const componentsWidth = actions.components.width;
+
+        if (searchConfig) iconLength++;
+
+        if (iconLength + componentsLength < 1) return 0;
+
+        return iconLength * (ICON_SIZE * fontScale + ICON_SPACING) + componentsWidth;
+    }, [actions, searchConfig, fontScale]);
+
+    return (
+        <Animated.View
+            style={[
+                searching ? defaultStyles.searchContainer : defaultStyles.titleContainer,
+                searching
+                    ? {}
+                    : {
+                          marginRight: headerHeight.interpolate({
+                              inputRange: [REGULAR_HEIGHT, EXTENDED_HEIGHT],
+                              outputRange: [getActionPanelWidth(), 0],
+                              extrapolate: 'clamp',
+                          }),
+                          marginBottom: subtitle && title ? 5 * fontScale : 15 * fontScale,
+                      },
+                styles.root,
+            ]}
+        >
+            <View style={{ flex: 0, justifyContent: 'center' }}>{content}</View>
+        </Animated.View>
+    );
+};

--- a/components/src/md3/Header/headerContent.tsx
+++ b/components/src/md3/Header/headerContent.tsx
@@ -105,7 +105,6 @@ type HeaderSubtitleProps = {
 
     /** Style to apply to the Text element */
     style?: StyleProp<TextStyle>;
-
 };
 /**
  * HeaderSubtitle component
@@ -304,7 +303,6 @@ export type HeaderContentProps = {
      * Theme value overrides specific to this component.
      */
     theme: MD3Theme;
-
 };
 
 /**
@@ -337,12 +335,7 @@ export const HeaderContent: React.FC<HeaderContentProps> = (props) => {
         content = [
             <HeaderTitle title={title} key="title_key" theme={theme} style={[styles.title]} />,
             <HeaderInfo info={info} key="info_key" theme={theme} style={[styles.info]} />,
-            <HeaderSubtitle
-                subtitle={subtitle}
-                key="subtitle_key"
-                theme={theme}
-                style={[styles.subtitle]}
-            />,
+            <HeaderSubtitle subtitle={subtitle} key="subtitle_key" theme={theme} style={[styles.subtitle]} />,
         ];
     }
 

--- a/components/src/md3/Header/headerIcon.tsx
+++ b/components/src/md3/Header/headerIcon.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { Icon } from '../Icon';
+import { useFontScaleSettings } from '../__contexts__/font-scale-context';
+import { IconSource } from '../__types__';
+import { ICON_SIZE } from './constants';
+import { useColor } from './contexts/ColorContextProvider';
+
+type HeaderIconProps = {
+    /** A component to render for the icon  */
+    icon?: IconSource;
+};
+/**
+ * HeaderIcon component
+ *
+ * The HeaderIcon is a helper component that is used to properly size and space icons in the Header component.
+ */
+export const HeaderIcon: React.FC<HeaderIconProps> = (props) => {
+    const { icon } = props;
+    const { color } = useColor();
+    const { disableScaling } = useFontScaleSettings();
+    if (icon) {
+        return <Icon source={icon} size={ICON_SIZE} color={color} allowFontScaling={!disableScaling} />;
+    }
+    return null;
+};

--- a/components/src/md3/Header/headerNavigationIcon.tsx
+++ b/components/src/md3/Header/headerNavigationIcon.tsx
@@ -1,0 +1,85 @@
+import React from 'react';
+import { TouchableOpacity, StyleSheet, StyleProp, ViewStyle, I18nManager } from 'react-native';
+import { ICON_SIZE } from './constants';
+import { IconSource } from '../__types__';
+import Icon from 'react-native-vector-icons/MaterialIcons';
+import { HeaderIcon } from './headerIcon';
+import { useSearch } from './contexts/SearchContextProvider';
+import { useColor } from './contexts/ColorContextProvider';
+import { useFontScale, useFontScaleSettings } from '../__contexts__/font-scale-context';
+
+const makeStyles = (): StyleSheet.NamedStyles<{
+    navigation: ViewStyle;
+    flipIcon: ViewStyle;
+}> => {
+    const fontScale = useFontScale();
+    return StyleSheet.create({
+        navigation: {
+            height: 40 * fontScale,
+            width: 40 * fontScale,
+            marginLeft: -8 * fontScale,
+            marginRight: 24,
+            marginTop: 8 * fontScale,
+            padding: 8 * fontScale,
+        },
+        flipIcon: {
+            transform: [{ scaleX: -1 }],
+        },
+    });
+};
+type HeaderNavigationProps = {
+    /** A component to render for the navigation icon */
+    icon?: IconSource;
+
+    /** A callback function to call when the icon is pressed */
+    onPress?: () => void;
+
+    /** Style to apply to the Touchable element */
+    style?: StyleProp<ViewStyle>;
+};
+/**
+ * HeaderNavigationIcon component
+ *
+ * The HeaderNavigationIcon is a helper component that is used to properly size and space the main navigation icon (on the left) in the Header component.
+ */
+export const HeaderNavigationIcon: React.FC<HeaderNavigationProps> = (props) => {
+    const { icon, onPress, style } = props;
+    const { searching, onClose } = useSearch();
+    const { color } = useColor();
+    const defaultStyles = makeStyles();
+    const { disableScaling, maxScale } = useFontScaleSettings();
+
+    if (searching) {
+        return (
+            <TouchableOpacity
+                testID={'header-search-close'}
+                accessibilityLabel={'header-search-close'}
+                onPress={onClose ? (): void => onClose() : undefined}
+                style={[defaultStyles.navigation, style]}
+            >
+                <Icon
+                    name={'arrow-back'}
+                    size={ICON_SIZE}
+                    color={color}
+                    allowFontScaling={!disableScaling}
+                    style={I18nManager.isRTL ? defaultStyles.flipIcon : {}}
+                    maxFontSizeMultiplier={maxScale}
+                />
+            </TouchableOpacity>
+        );
+    }
+    if (icon) {
+        return (
+            <TouchableOpacity
+                testID={'header-navigation'}
+                accessibilityLabel={'header-navigation'}
+                onPress={onPress}
+                style={[defaultStyles.navigation, style]}
+                disabled={!onPress}
+            >
+                <HeaderIcon icon={icon} />
+            </TouchableOpacity>
+        );
+    }
+    return null;
+};

--- a/components/src/md3/Header/index.ts
+++ b/components/src/md3/Header/index.ts
@@ -1,2 +1,2 @@
-export * from './Header'
+export * from './Header';
 export * from './constants';

--- a/components/src/md3/Header/index.ts
+++ b/components/src/md3/Header/index.ts
@@ -1,0 +1,2 @@
+export * from './Header'
+export * from './constants';

--- a/components/src/md3/Hero/Hero.tsx
+++ b/components/src/md3/Hero/Hero.tsx
@@ -90,7 +90,10 @@ export const Hero: React.FC<HeroProps> = (props) => {
         return Math.max(10, Math.min(48, iconSize));
     }, [iconSize]);
     // @TODO update the color once the theme creation is complete
-    const getColor = useCallback((color: string | undefined): string => color || theme.colors.onSurfaceVariant, [theme]);
+    const getColor = useCallback(
+        (color: string | undefined): string => color || theme.colors.onSurfaceVariant,
+        [theme]
+    );
 
     const getIcon = useCallback((): JSX.Element | undefined => {
         if (icon) {
@@ -105,7 +108,15 @@ export const Hero: React.FC<HeroProps> = (props) => {
             style={[defaultStyles.root, styles.root, style]}
             {...viewProps}
         >
-            <View style={[defaultStyles.iconWrapper,{ backgroundColor: iconBackgroundColor || theme.colors.surface }, styles.iconWrapper]}>{getIcon()}</View>
+            <View
+                style={[
+                    defaultStyles.iconWrapper,
+                    { backgroundColor: iconBackgroundColor || theme.colors.surface },
+                    styles.iconWrapper,
+                ]}
+            >
+                {getIcon()}
+            </View>
             <View style={[defaultStyles.values, styles.values]}>
                 {!children && !!ChannelValueProps?.value && <ChannelValue fontSize={22} {...ChannelValueProps} />}
                 {children}

--- a/components/src/md3/__hooks__/useHeaderDimensions.tsx
+++ b/components/src/md3/__hooks__/useHeaderDimensions.tsx
@@ -1,0 +1,52 @@
+import { useWindowDimensions } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { useFontScale } from '../__contexts__/font-scale-context';
+
+export type HeaderDimensions = {
+    REGULAR_HEIGHT: number;
+    EXTENDED_HEIGHT: number;
+    LANDSCAPE: boolean;
+    getScaledHeight: (height: number) => number;
+};
+/**
+ * useHeaderDimensions hook
+ *
+ * This hook is used to provide the 'constant' values for the Header height in the collapsed
+ * and expanded states. These values can change when the device rotates based on the safe areas
+ * and presence or absence of a status bar.
+ *
+ * This hook listens for device rotation changes and makes sure the the correct constant values
+ * are being returned
+ *
+ * @returns { REGULAR_HEIGHT, EXTENDED_HEIGHT, LANDSCAPE, getScaledHeight }
+ */
+export const useHeaderDimensions = (): HeaderDimensions => {
+    const { width: deviceWidth, height: deviceHeight } = useWindowDimensions();
+    const fontScale = useFontScale();
+    const insets = useSafeAreaInsets();
+    const isLandscape = deviceWidth > deviceHeight;
+
+    const heightWithStatusBar = (height: number): number => height * fontScale + insets.top;
+    const heightWithoutStatusBar = (height: number): number => height * fontScale;
+
+    const LANDSCAPE_HEIGHT = {
+        EXTENDED: heightWithoutStatusBar(200),
+        REGULAR: heightWithoutStatusBar(56),
+    };
+    const PORTRAIT_HEIGHT = {
+        EXTENDED: heightWithStatusBar(200),
+        REGULAR: heightWithStatusBar(56),
+    };
+
+    const REGULAR_HEIGHT = isLandscape ? LANDSCAPE_HEIGHT.REGULAR : PORTRAIT_HEIGHT.REGULAR;
+    const EXTENDED_HEIGHT = isLandscape ? LANDSCAPE_HEIGHT.EXTENDED : PORTRAIT_HEIGHT.EXTENDED;
+
+    const getScaledHeight = isLandscape ? heightWithoutStatusBar : heightWithStatusBar;
+
+    return {
+        REGULAR_HEIGHT,
+        EXTENDED_HEIGHT,
+        LANDSCAPE: isLandscape,
+        getScaledHeight,
+    };
+};

--- a/components/src/md3/__hooks__/usePrevious.tsx
+++ b/components/src/md3/__hooks__/usePrevious.tsx
@@ -1,0 +1,23 @@
+import { useRef, useEffect } from 'react';
+
+/**
+ * usePrevious hook
+ *
+ * This hook is used to track the previous version of a variable from a prior
+ * render for the purposes of conditionally updating aspects of a component based on
+ * whether particular variables have changed.
+ */
+/* eslint-disable-next-line @typescript-eslint/ban-types */
+export const usePrevious = <T extends {}>(value: T): T | undefined => {
+    // The ref object is a generic container whose current property is mutable ...
+    // ... and can hold any value, similar to an instance property on a class
+    const ref = useRef<T>();
+
+    // Store current value in ref
+    useEffect(() => {
+        ref.current = value;
+    }, [value]); // Only re-run if value changes
+
+    // Return previous value (happens before update in useEffect above)
+    return ref.current;
+};

--- a/components/src/md3/index.ts
+++ b/components/src/md3/index.ts
@@ -3,3 +3,4 @@ export * from './ListItemTag';
 export * from './Icon';
 export * from './Overline';
 export * from './EmptyState';
+export * from './Header';


### PR DESCRIPTION
Changes proposed in this Pull Request:
- Add Header Component
- 
- 

Screenshots / Screen Recording (if applicable)
-
<img width="706" alt="Screenshot 2023-10-10 at 2 00 13 PM" src="https://github.com/etn-ccis/blui-react-native-component-library/assets/144440086/f3bed871-cc43-4b1a-b68d-246a9520e8e5">

<img width="706" alt="Screenshot 2023-10-10 at 2 00 22 PM" src="https://github.com/etn-ccis/blui-react-native-component-library/assets/144440086/37169d63-3490-4fb5-83b5-99679292050c">



To Test:
-run yarn start:showcase-ios 




