### PR TITLE
Migrate the Spacer component to MD3

### DIFF
--- a/components/src/md3/index.ts
+++ b/components/src/md3/index.ts
@@ -9,3 +9,4 @@ export * from './Header';
 export * from './MobileStepper';
 export * from './ScoreCard';
 export * from './CollapsableHeaderLayout';
+export * from './utility';

--- a/components/src/md3/utility/Spacer.test.tsx
+++ b/components/src/md3/utility/Spacer.test.tsx
@@ -1,0 +1,100 @@
+import React from 'react';
+import TestRenderer from 'react-test-renderer';
+import { StyleSheet, ViewStyle } from 'react-native';
+import { cleanup } from '@testing-library/react-native';
+import { Spacer } from './Spacer';
+
+describe('spacer', () => {
+    afterEach(cleanup);
+    it('renders the correct default style', () => {
+        const instance = TestRenderer.create(<Spacer />).root;
+        const spacer = instance.find((x) => x.props.testID === 'spacer-root');
+        expect(spacer.props.style).toMatchObject([
+            {
+                flex: 1,
+                width: 'auto',
+                height: 'auto',
+            },
+            undefined,
+            undefined,
+        ]);
+    });
+
+    it('passes in the inherited view props', () => {
+        const instance = TestRenderer.create(<Spacer removeClippedSubviews={true} />).root;
+        const spacer = instance.find((x) => x.props.testID === 'spacer-root');
+        expect(spacer.props).toMatchObject({ removeClippedSubviews: true });
+    });
+
+    it('renders flex properties', () => {
+        let instance = TestRenderer.create(<Spacer flex={2} />).root;
+        let spacer = instance.find((x) => x.props.testID === 'spacer-root');
+        expect(spacer.props.style).toMatchObject([
+            {
+                flex: 2,
+                width: 'auto',
+                height: 'auto',
+            },
+            undefined,
+            undefined,
+        ]);
+
+        instance = TestRenderer.create(<Spacer flex={3} />).root;
+        spacer = instance.find((x) => x.props.testID === 'spacer-root');
+        expect(spacer.props.style).toMatchObject([
+            {
+                flex: 3,
+                width: 'auto',
+                height: 'auto',
+            },
+            undefined,
+            undefined,
+        ]);
+
+        instance = TestRenderer.create(<Spacer flex={0} />).root;
+        spacer = instance.find((x) => x.props.testID === 'spacer-root');
+        expect(spacer.props.style).toMatchObject([
+            {
+                flex: 0,
+                width: 'auto',
+                height: 'auto',
+            },
+            undefined,
+            undefined,
+        ]);
+    });
+
+    it('renders static properties', () => {
+        const instance = TestRenderer.create(<Spacer flex={0} width={42} height={123} />).root;
+        const spacer = instance.find((x) => x.props.testID === 'spacer-root');
+        expect(spacer.props.style).toMatchObject([
+            {
+                flex: 0,
+                width: 42,
+                height: 123,
+            },
+            undefined,
+            undefined,
+        ]);
+    });
+
+    it('accepts style overrides', () => {
+        const spacerStyles: StyleSheet.NamedStyles<{
+            root: ViewStyle;
+        }> = StyleSheet.create({
+            root: {
+                flexGrow: 12,
+                color: 'red',
+                height: '30%',
+                width: '1rem',
+            },
+        });
+        const instance = TestRenderer.create(<Spacer styles={spacerStyles} style={{ borderRadius: 3 }} />).root;
+        const spacer = instance.find((x) => x.props.testID === 'spacer-root');
+        expect(spacer.props.style).toMatchObject([
+            { flex: 1, height: 'auto', width: 'auto' },
+            { color: 'red', flexGrow: 12, height: '30%', width: '1rem' },
+            { borderRadius: 3 },
+        ]);
+    });
+});


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
Fixes #BLUI-4820 .

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- Added test file of Spacer in the md3 folder.
- Exported utility folder.
- Please check this PR for KitchenSink updates [Spacer component](https://github.com/etn-ccis/blui-react-native-showcase-demo/pull/96).

<!-- Include screenshots if they will help illustrate the changes in this PR -->

#### Screenshots / Screen Recording (if applicable)
<img width="329" alt="Screenshot 2023-10-26 at 4 37 30 PM" src="https://github.com/etn-ccis/blui-react-native-component-library/assets/130662346/96b4d4af-18cd-449d-9d06-cc1f4561b308">


<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->
#### To Test:
- yarn start

<!-- Useful for draft pull requests -->
#### Any specific feedback you are looking for?
-


