### PR TITLE
Refactor grades exports

### DIFF
--- a/components/src/md3/Grades/Grades.tsx
+++ b/components/src/md3/Grades/Grades.tsx
@@ -1,18 +1,20 @@
 import React from 'react';
-import { Avatar } from 'react-native-paper';
+import { ViewProps } from 'react-native';
+import { Avatar, useTheme } from 'react-native-paper';
 
-export type CustomGradeProps = {
+export type GradeProps = ViewProps & {
     label: string;
-    color: string;
-    backgroundColor: string;
-    size: number;
-};
-
-export type GradeProps = {
-    label?: string;
+    color?: string;
+    backgroundColor?: string;
     size?: number;
 };
-export const CustomGrade: React.FC<CustomGradeProps> = ({ label, color, backgroundColor, size }) => {
+
+export type FixedGradeProps = Pick<GradeProps, 'size'>;
+
+const GradeBase = (props: GradeProps) => {
+    const theme = useTheme();
+    const { label, color = theme.colors.onPrimary, backgroundColor = theme.colors.primary, size = 40, style, ...otherViewProps } = props;
+    
     const avatarStyle = {
         backgroundColor,
     };
@@ -26,63 +28,55 @@ export const CustomGrade: React.FC<CustomGradeProps> = ({ label, color, backgrou
     return (
         <Avatar.Text
             label={label}
-            style={avatarStyle}
+            style={[avatarStyle, style]}
             color={color}
             labelStyle={textStyle}
-            size={size || 40}
+            size={size}
             testID="grade"
+            {...otherViewProps}
         />
     );
 };
 
-export const Grades = {
-    aPlus: (props: GradeProps): JSX.Element => (
-        <CustomGrade label={props.label || 'A+'} color="#FFFFFF" backgroundColor="#198900" size={props.size || 40} />
-    ),
-    a: (props: GradeProps): JSX.Element => (
-        <CustomGrade label={props.label || 'A'} color="#FFFFFF" backgroundColor="#198900" size={props.size || 40} />
-    ),
-    aMinus: (props: GradeProps): JSX.Element => (
-        <CustomGrade label={props.label || 'A-'} color="#FFFFFF" backgroundColor="#64a721" size={props.size || 40} />
-    ),
-    bPlus: (props: GradeProps): JSX.Element => (
-        <CustomGrade label={props.label || 'B+'} color="#524700" backgroundColor="#afc543" size={props.size || 40} />
-    ),
-    b: (props: GradeProps): JSX.Element => (
-        <CustomGrade label={props.label || 'B'} color="#524700" backgroundColor="#FBE365" size={props.size || 40} />
-    ),
-    bMinus: (props: GradeProps): JSX.Element => (
-        <CustomGrade label={props.label || 'B-'} color="#524700" backgroundColor="#f6c543" size={props.size || 40} />
-    ),
-    cPlus: (props: GradeProps): JSX.Element => (
-        <CustomGrade label={props.label || 'C+'} color="#4B2800" backgroundColor="#f1a821" size={props.size || 40} />
-    ),
-    c: (props: GradeProps): JSX.Element => (
-        <CustomGrade label={props.label || 'C'} color="#4B2800" backgroundColor="#ED8B00" size={props.size || 40} />
-    ),
-    cMinus: (props: GradeProps): JSX.Element => (
-        <CustomGrade label={props.label || 'C-'} color="#4B2800" backgroundColor="#dc6508" size={props.size || 40} />
-    ),
-    dPlus: (props: GradeProps): JSX.Element => (
-        <CustomGrade label={props.label || 'D+'} color="#FFFFFF" backgroundColor="#cb3f11" size={props.size || 40} />
-    ),
-    d: (props: GradeProps): JSX.Element => (
-        <CustomGrade label={props.label || 'D'} color="#FFFFFF" backgroundColor="#BA1A1A" size={props.size || 40} />
-    ),
-    dMinus: (props: GradeProps): JSX.Element => (
-        <CustomGrade label={props.label || 'D-'} color="#FFFFFF" backgroundColor="#BA1A1A" size={props.size || 40} />
-    ),
-    f: (props: GradeProps): JSX.Element => (
-        <CustomGrade label={props.label || 'F'} color="#FFFFFF" backgroundColor="#9F45F6" size={props.size || 40} />
-    ),
-    custom: (props: CustomGradeProps): JSX.Element => (
-        <CustomGrade
-            label={props.label}
-            color={props.color}
-            backgroundColor={props.backgroundColor}
-            size={props.size}
-        />
-    ),
-};
+GradeBase.APlus = (props: FixedGradeProps): JSX.Element => (
+    <GradeBase label={'A+'} color="#FFFFFF" backgroundColor="#198900" size={props.size} />
+);
+GradeBase.A = (props: FixedGradeProps): JSX.Element => (
+    <GradeBase label={'A'} color="#FFFFFF" backgroundColor="#198900" size={props.size} />
+);
+GradeBase.AMinus = (props: FixedGradeProps): JSX.Element => (
+    <GradeBase label={'A-'} color="#FFFFFF" backgroundColor="#64a721" size={props.size} />
+);
+GradeBase.BPlus = (props: FixedGradeProps): JSX.Element => (
+    <GradeBase label={'B+'} color="#524700" backgroundColor="#afc543" size={props.size} />
+);
+GradeBase.B = (props: FixedGradeProps): JSX.Element => (
+    <GradeBase label={'B'} color="#524700" backgroundColor="#FBE365" size={props.size} />
+);
+GradeBase.BMinus = (props: FixedGradeProps): JSX.Element => (
+    <GradeBase label={'B-'} color="#524700" backgroundColor="#f6c543" size={props.size} />
+);
+GradeBase.CPlus = (props: FixedGradeProps): JSX.Element => (
+    <GradeBase label={'C+'} color="#4B2800" backgroundColor="#f1a821" size={props.size} />
+);
+GradeBase.C = (props: FixedGradeProps): JSX.Element => (
+    <GradeBase label={'C'} color="#4B2800" backgroundColor="#ED8B00" size={props.size} />
+);
+GradeBase.CMinus = (props: FixedGradeProps): JSX.Element => (
+    <GradeBase label={'C-'} color="#4B2800" backgroundColor="#dc6508" size={props.size} />
+);
+GradeBase.DPlus = (props: FixedGradeProps): JSX.Element => (
+    <GradeBase label={'D+'} color="#FFFFFF" backgroundColor="#cb3f11" size={props.size} />
+);
+GradeBase.D = (props: FixedGradeProps): JSX.Element => (
+    <GradeBase label={'D'} color="#FFFFFF" backgroundColor="#BA1A1A" size={props.size} />
+);
+GradeBase.DMinus = (props: FixedGradeProps): JSX.Element => (
+    <GradeBase label={'D-'} color="#FFFFFF" backgroundColor="#BA1A1A" size={props.size} />
+);
+GradeBase.F = (props: FixedGradeProps): JSX.Element => (
+    <GradeBase label={'F'} color="#FFFFFF" backgroundColor="#9F45F6" size={props.size} />
+);
 
-export default Grades;
+export const Grade = GradeBase;
+export default Grade;

--- a/components/src/md3/Grades/Grades.tsx
+++ b/components/src/md3/Grades/Grades.tsx
@@ -9,12 +9,19 @@ export type GradeProps = ViewProps & {
     size?: number;
 };
 
-export type FixedGradeProps = Pick<GradeProps, 'size'>;
+export type FixedGradeProps = Omit<GradeProps, 'label' | 'color' | 'backgroundColor'>;
 
 const GradeBase = (props: GradeProps) => {
     const theme = useTheme();
-    const { label, color = theme.colors.onPrimary, backgroundColor = theme.colors.primary, size = 40, style, ...otherViewProps } = props;
-    
+    const {
+        label,
+        color = theme.colors.onPrimary,
+        backgroundColor = theme.colors.primary,
+        size = 40,
+        style,
+        ...otherViewProps
+    } = props;
+
     const avatarStyle = {
         backgroundColor,
     };
@@ -39,43 +46,43 @@ const GradeBase = (props: GradeProps) => {
 };
 
 GradeBase.APlus = (props: FixedGradeProps): JSX.Element => (
-    <GradeBase label={'A+'} color="#FFFFFF" backgroundColor="#198900" size={props.size} />
+    <GradeBase label={'A+'} color="#FFFFFF" backgroundColor="#198900" {...props} />
 );
 GradeBase.A = (props: FixedGradeProps): JSX.Element => (
-    <GradeBase label={'A'} color="#FFFFFF" backgroundColor="#198900" size={props.size} />
+    <GradeBase label={'A'} color="#FFFFFF" backgroundColor="#198900" {...props} />
 );
 GradeBase.AMinus = (props: FixedGradeProps): JSX.Element => (
-    <GradeBase label={'A-'} color="#FFFFFF" backgroundColor="#64a721" size={props.size} />
+    <GradeBase label={'A-'} color="#FFFFFF" backgroundColor="#64a721" {...props} />
 );
 GradeBase.BPlus = (props: FixedGradeProps): JSX.Element => (
-    <GradeBase label={'B+'} color="#524700" backgroundColor="#afc543" size={props.size} />
+    <GradeBase label={'B+'} color="#524700" backgroundColor="#afc543" {...props} />
 );
 GradeBase.B = (props: FixedGradeProps): JSX.Element => (
-    <GradeBase label={'B'} color="#524700" backgroundColor="#FBE365" size={props.size} />
+    <GradeBase label={'B'} color="#524700" backgroundColor="#FBE365" {...props} />
 );
 GradeBase.BMinus = (props: FixedGradeProps): JSX.Element => (
-    <GradeBase label={'B-'} color="#524700" backgroundColor="#f6c543" size={props.size} />
+    <GradeBase label={'B-'} color="#524700" backgroundColor="#f6c543" {...props} />
 );
 GradeBase.CPlus = (props: FixedGradeProps): JSX.Element => (
-    <GradeBase label={'C+'} color="#4B2800" backgroundColor="#f1a821" size={props.size} />
+    <GradeBase label={'C+'} color="#4B2800" backgroundColor="#f1a821" {...props} />
 );
 GradeBase.C = (props: FixedGradeProps): JSX.Element => (
-    <GradeBase label={'C'} color="#4B2800" backgroundColor="#ED8B00" size={props.size} />
+    <GradeBase label={'C'} color="#4B2800" backgroundColor="#ED8B00" {...props} />
 );
 GradeBase.CMinus = (props: FixedGradeProps): JSX.Element => (
-    <GradeBase label={'C-'} color="#4B2800" backgroundColor="#dc6508" size={props.size} />
+    <GradeBase label={'C-'} color="#4B2800" backgroundColor="#dc6508" {...props} />
 );
 GradeBase.DPlus = (props: FixedGradeProps): JSX.Element => (
-    <GradeBase label={'D+'} color="#FFFFFF" backgroundColor="#cb3f11" size={props.size} />
+    <GradeBase label={'D+'} color="#FFFFFF" backgroundColor="#cb3f11" {...props} />
 );
 GradeBase.D = (props: FixedGradeProps): JSX.Element => (
-    <GradeBase label={'D'} color="#FFFFFF" backgroundColor="#BA1A1A" size={props.size} />
+    <GradeBase label={'D'} color="#FFFFFF" backgroundColor="#BA1A1A" {...props} />
 );
 GradeBase.DMinus = (props: FixedGradeProps): JSX.Element => (
-    <GradeBase label={'D-'} color="#FFFFFF" backgroundColor="#BA1A1A" size={props.size} />
+    <GradeBase label={'D-'} color="#FFFFFF" backgroundColor="#BA1A1A" {...props} />
 );
 GradeBase.F = (props: FixedGradeProps): JSX.Element => (
-    <GradeBase label={'F'} color="#FFFFFF" backgroundColor="#9F45F6" size={props.size} />
+    <GradeBase label={'F'} color="#FFFFFF" backgroundColor="#9F45F6" {...props} />
 );
 
 export const Grade = GradeBase;

--- a/components/src/md3/Grades/Grades.tsx
+++ b/components/src/md3/Grades/Grades.tsx
@@ -11,7 +11,7 @@ export type GradeProps = ViewProps & {
 
 export type FixedGradeProps = Omit<GradeProps, 'label' | 'color' | 'backgroundColor'>;
 
-const GradeBase = (props: GradeProps) => {
+const GradeBase = (props: GradeProps): JSX.Element => {
     const theme = useTheme();
     const {
         label,


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->


<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
Refactor Grade component:
- Export customizable grade as the base component
- Fixed grades exported as subcomponents
- Use capitalized names for subcomponents
- Extend types from View to allow for things like adding margins easily
- Make props optional and use reasonable defaults

Usage now looks like:
```tsx
<Grade.APlus style={{ marginBottom: 10 }} />
<Grade.A style={{ marginBottom: 10 }} />
<Grade.AMinus style={{ marginBottom: 10 }} />
<Grade.BPlus style={{ marginBottom: 10 }} />
<Grade.B style={{ marginBottom: 10 }} />
<Grade.BMinus style={{ marginBottom: 10 }} />
<Grade.CPlus style={{ marginBottom: 10 }} />
<Grade.C style={{ marginBottom: 10 }} />
<Grade.CMinus style={{ marginBottom: 10 }} />
<Grade.DPlus style={{ marginBottom: 10 }} />
<Grade.D style={{ marginBottom: 10 }} />
<Grade.DMinus style={{ marginBottom: 10 }} />
<Grade.F style={{ marginBottom: 10 }} />
<Grade label="CS" size={40} />
```
<!-- Include screenshots if they will help illustrate the changes in this PR -->
#### Screenshots / Screen Recording (if applicable)
![image](https://github.com/etn-ccis/blui-react-native-component-library/assets/29152776/a6d2fc81-9730-49d0-b805-7cca99061134)


