### PR TITLE
Calculate ChannelValue lineHeight as per fontSize

### DIFF
--- a/components/src/md3/ChannelValue/ChannelValue.tsx
+++ b/components/src/md3/ChannelValue/ChannelValue.tsx
@@ -8,6 +8,7 @@ import { IconSource } from '../__types__';
 
 const prefixUnitWhitelist = ['$'];
 const suffixUnitWhitelist = ['%', '℉', '°F', '℃', '°C', '°'];
+const calculateHeight = (fontSize: number): number => Math.ceil((fontSize * 1.25) / 4) * 4;
 
 const defaultStyles = StyleSheet.create({
     root: {
@@ -127,13 +128,14 @@ export const ChannelValue: React.FC<ChannelValueProps> = (props) => {
                                 unitSpace === 'auto' &&
                                 !suffixUnitWhitelist.includes(units))) && <Spacer flex={0} width={fontSize / 4} />}
                         <Text
-                            variant={'bodyLarge'}
+                            variant={'titleMedium'}
                             style={[
                                 {
                                     color: getColor(),
                                     fontSize: fontSize,
                                     fontWeight: '300',
                                     fontFamily: 'OpenSans-Regular',
+                                    lineHeight: calculateHeight(fontSize),
                                 },
                                 styles.units,
                             ]}
@@ -167,7 +169,7 @@ export const ChannelValue: React.FC<ChannelValueProps> = (props) => {
         <View style={[defaultStyles.root, styles.root, style]} {...viewProps}>
             {getIcon()}
             <Text
-                variant={'bodyLarge'}
+                variant={'titleMedium'}
                 numberOfLines={1}
                 ellipsizeMode={'tail'}
                 testID={'text-wrapper'}
@@ -175,6 +177,7 @@ export const ChannelValue: React.FC<ChannelValueProps> = (props) => {
                     {
                         color: getColor(),
                         fontSize: fontSize,
+                        lineHeight: calculateHeight(fontSize),
                         fontFamily: 'OpenSans-SemiBold',
                         fontWeight: '600',
                     },
@@ -182,13 +185,14 @@ export const ChannelValue: React.FC<ChannelValueProps> = (props) => {
             >
                 {prefixUnits()}
                 <Text
-                    variant={'bodyLarge'}
+                    variant={'titleMedium'}
                     style={[
                         {
                             color: getColor(),
                             fontSize: fontSize,
                             fontFamily: 'OpenSans-SemiBold',
                             fontWeight: '600',
+                            lineHeight: calculateHeight(fontSize),
                         },
                         styles.value,
                     ]}

--- a/components/src/md3/Drawer/DrawerNavItem.tsx
+++ b/components/src/md3/Drawer/DrawerNavItem.tsx
@@ -128,6 +128,7 @@ const makeStyles = (
         activeItemBackgroundShape = 'square',
         backgroundColor,
         depth,
+        // @ts-ignore TODO
         nestedBackgroundColor = theme.colors.surfaceContainer, // TODO: don't hardcode?
     } = props;
 
@@ -180,6 +181,7 @@ export const DrawerNavItem: React.FC<DrawerNavItemProps> = (props) => {
     const previousActive = usePrevious(activeItem || '');
 
     // approximating primary[200] but we don't have access to it directly from the theme
+    /* eslint-disable-next-line @typescript-eslint/no-unused-vars */ //TODO: Do we need this variable?
     const lightenedPrimary = color(getPrimary500(theme) || theme.colors.primary)
         .lighten(0.83)
         .desaturate(0.39)

--- a/components/src/md3/Drawer/DrawerNavItem.tsx
+++ b/components/src/md3/Drawer/DrawerNavItem.tsx
@@ -4,7 +4,6 @@ import { InfoListItem, InfoListItemProps as BLUIInfoListItemProps } from '../Inf
 import { MD3Theme, useTheme } from 'react-native-paper';
 import { usePrevious } from '../__hooks__/usePrevious';
 import { AllSharedProps } from './types';
-import color from 'color';
 import { useDrawerContext } from './context/drawer-context';
 import { useNavGroupContext } from './context/nav-group-context';
 import { findChildByType, inheritSharedProps } from './utilities';
@@ -14,7 +13,6 @@ import { IconSource } from '../__types__';
 import { Icon } from '../Icon';
 import { useFontScale, useFontScaleSettings } from '../__contexts__/font-scale-context';
 import MatIcon from 'react-native-vector-icons/MaterialIcons';
-import { getPrimary500 } from '../utility/Shared';
 
 export type DrawerNavItemStyles = {
     root?: StyleProp<ViewStyle>;
@@ -179,13 +177,6 @@ export const DrawerNavItem: React.FC<DrawerNavItemProps> = (props) => {
     const { activeItem, onItemSelect } = useDrawerContext();
     const { activeHierarchy } = useNavGroupContext();
     const previousActive = usePrevious(activeItem || '');
-
-    // approximating primary[200] but we don't have access to it directly from the theme
-    /* eslint-disable-next-line @typescript-eslint/no-unused-vars */ //TODO: Do we need this variable?
-    const lightenedPrimary = color(getPrimary500(theme) || theme.colors.primary)
-        .lighten(0.83)
-        .desaturate(0.39)
-        .string();
 
     const {
         // Shared style props


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
Fixes 4872 .

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- Calculate channelValue line-height as per font size. For e.g 
fontSize 12px - lineHeight 16
fontSize 14px - lineHeight 20
fontSize 16px - lineheight 20 
fontSize 22px -  lineheight 28
fontSize 32px - lineHeight 40


<!-- Include screenshots if they will help illustrate the changes in this PR -->
#### Screenshots / Screen Recording (if applicable)
-
<img width="373" alt="Screenshot 2023-11-02 at 5 47 18 PM" src="https://github.com/etn-ccis/blui-react-native-component-library/assets/133877691/ba23a0ae-e29f-4b7d-942a-2d46c5d36bdc">



<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->
#### To Test:
- Run showcase [demo](https://github.com/etn-ccis/blui-react-native-showcase-demo/pull/103) 

<!-- Useful for draft pull requests -->
#### Any specific feedback you are looking for?
- Currently, I am adding **lineHeight 20** when the **fontSize is 16** but as per Figma it is **24px**. Is it okay to have a 20px lineHeight or Do I need to add a fix specific to 16px?


