### PR TITLE
Bug/5005 461 hero banner divider color

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,9 @@
 
 ### Changed
 
-- The default direction of `IconFamily` to `rtl` ([#180](https://github.com/etn-ccis/blui-react-native-component-library/issues/180)).
-- The default icon background color for Hero changed from `theme.colors.surface` to 'transparent'.
+-   The default direction of `IconFamily` to `rtl` ([#180](https://github.com/etn-ccis/blui-react-native-component-library/issues/180)).
+-   The default icon background color for Hero changed from `theme.colors.surface` to 'transparent'.
+-   The color of divider in `<HeroBanner>` ([#461](https://github.com/etn-ccis/blui-react-native-component-library/issues/461)).
 
 ## v7.1.0 (April 12, 2023)
 

--- a/components/src/core/HeroBanner/HeroBanner.tsx
+++ b/components/src/core/HeroBanner/HeroBanner.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { StyleSheet, View, StyleProp, ViewStyle, ViewProps } from 'react-native';
 import { Divider } from 'react-native-paper';
+import * as BLUIColors from '@brightlayer-ui/colors';
 
 const defaultStyles = StyleSheet.create({
     root: {
@@ -47,7 +48,7 @@ export const HeroBanner: React.FC<HeroBannerProps> = (props) => {
                 {childrenArray}
                 {divider && (
                     <View style={defaultStyles.divider}>
-                        <Divider />
+                        <Divider style={{ backgroundColor: BLUIColors.neutralVariant[50] }} />
                     </View>
                 )}
             </View>

--- a/demos/api/src/utils.ts
+++ b/demos/api/src/utils.ts
@@ -2,7 +2,7 @@ export const updateTitle = (): void => {
     setTimeout(() => {
         window.top.document.title = 'Brightlayer UI | React Native Components';
     }, 10);
-    (function() {
+    (function () {
         var link = window.top.document.querySelector("link[rel*='icon']") || document.createElement('link');
         // @ts-ignore
         link.type = 'image/x-icon';


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
Fixes #461 BLUI-5005

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- Updated hero banner divider color to be neutralVariant[50]

<!-- Include screenshots if they will help illustrate the changes in this PR -->
#### Screenshots / Screen Recording (if applicable)
- 
![Simulator Screenshot - iphone 12 pro - 2023-12-12 at 15 24 06](https://github.com/etn-ccis/blui-react-native-component-library/assets/120575281/a91c39ef-4d40-4b92-ba34-bd889226d569)

<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->
#### To Test:
- yarn start

<!-- Useful for draft pull requests -->
#### Any specific feedback you are looking for?
-


