### PR TITLE
Used textprops from react native paper for overline

### DIFF
--- a/components/src/core/Overline/Overline.tsx
+++ b/components/src/core/Overline/Overline.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import { TextStyle, StyleProp, StyleSheet } from 'react-native';
-import { Text } from 'react-native-paper';
+import { Text, TextProps } from 'react-native-paper';
 import { $DeepPartial } from '@callstack/react-theme-provider';
 import { useFontScaleSettings } from '../__contexts__/font-scale-context';
 import { ExtendedTheme, useExtendedTheme } from '@brightlayer-ui/react-native-themes';
 
-type OverlineProps = Omit<React.ComponentProps<typeof Text>, 'theme' | 'variant'> & {
+export type OverlineProps = Omit<TextProps<'labelMedium'>, 'theme' | 'variant'> & {
     /** Style overrides for internal elements. The styles you provide will be combined with the default styles. */
     styles?: {
         root?: StyleProp<TextStyle>;


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
Fixes # BLUI-5081

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- Extended TextProps from react native paper to overline
- Exported OverlineProps

<!-- Include screenshots if they will help illustrate the changes in this PR -->
#### Screenshots / Screen Recording (if applicable)
- 
![Simulator Screenshot - iphone 12 pro - 2024-01-04 at 13 58 52](https://github.com/etn-ccis/blui-react-native-component-library/assets/120575281/5fdead05-15bd-4bb8-bad6-07c9ffdaaa3a)

<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->
#### To Test:
- yarn start

<!-- Useful for draft pull requests -->
#### Any specific feedback you are looking for?
-


