### PR TITLE
Updated borderRadius multiplier to 4 times in ListItemTag

### DIFF
--- a/components/src/core/ListItemTag/ListItemTag.tsx
+++ b/components/src/core/ListItemTag/ListItemTag.tsx
@@ -54,7 +54,7 @@ const listItemTagStyles = (
             padding: 0,
             paddingLeft: 4 * fontScale,
             paddingRight: 3 * fontScale, // to account for the 1px letter spacing on the last letter
-            borderRadius: 2 * fontScale,
+            borderRadius: 4 * fontScale,
             fontWeight: '700',
             fontFamily: 'OpenSans-Bold',
             overflow: 'hidden',

--- a/components/src/core/ListItemTag/__snapshots__/ListItemTag.test.tsx.snap
+++ b/components/src/core/ListItemTag/__snapshots__/ListItemTag.test.tsx.snap
@@ -24,7 +24,7 @@ exports[`ListItemTag ListItemTag Renders 1`] = `
         [
           {
             "backgroundColor": undefined,
-            "borderRadius": 4,
+            "borderRadius": 8,
             "color": undefined,
             "fontFamily": "OpenSans-Bold",
             "fontSize": 10,


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
Fixes #500 BLUI-5091 .

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- Updated multiplier in border radius of ListItemTag

<!-- Include screenshots if they will help illustrate the changes in this PR -->
#### Screenshots / Screen Recording (if applicable)
- 
![Simulator Screenshot - iphone 12 pro - 2024-01-04 at 15 30 12](https://github.com/etn-ccis/blui-react-native-component-library/assets/120575281/9844ad86-3322-470f-9d4f-7d36ca3168bd)

<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->
#### To Test:
- yarn start

<!-- Useful for draft pull requests -->
#### Any specific feedback you are looking for?
-


