### PR TITLE
Update useFontWeight utitlity

### DIFF
--- a/components/package.json
+++ b/components/package.json
@@ -33,7 +33,7 @@
     },
     "prettier": "@brightlayer-ui/prettier-config",
     "dependencies": {
-        "@brightlayer-ui/react-native-themes": "7.0.1-alpha.3",
+        "@brightlayer-ui/react-native-themes": "7.0.1-alpha.4",
         "color": "^4.2.3",
         "react-native-collapsible": "^1.6.0",
         "react-native-keyboard-aware-scroll-view": "^0.9.5",

--- a/components/package.json
+++ b/components/package.json
@@ -33,7 +33,7 @@
     },
     "prettier": "@brightlayer-ui/prettier-config",
     "dependencies": {
-        "@brightlayer-ui/react-native-themes": "7.0.1-alpha.4",
+        "@brightlayer-ui/react-native-themes": "7.0.1-alpha.5",
         "color": "^4.2.3",
         "react-native-collapsible": "^1.6.0",
         "react-native-keyboard-aware-scroll-view": "^0.9.5",

--- a/components/package.json
+++ b/components/package.json
@@ -33,7 +33,7 @@
     },
     "prettier": "@brightlayer-ui/prettier-config",
     "dependencies": {
-        "@brightlayer-ui/react-native-themes": "7.0.0",
+        "@brightlayer-ui/react-native-themes": "7.0.1-alpha.3",
         "color": "^4.2.3",
         "react-native-collapsible": "^1.6.0",
         "react-native-keyboard-aware-scroll-view": "^0.9.5",

--- a/components/src/core/ChannelValue/ChannelValue.tsx
+++ b/components/src/core/ChannelValue/ChannelValue.tsx
@@ -6,7 +6,7 @@ import { Icon } from '../Icon';
 import { Spacer } from '../Utility';
 import { IconSource } from '../__types__';
 import { ExtendedTheme, useExtendedTheme } from '@brightlayer-ui/react-native-themes';
-import { calculateHeight } from '../Utility/shared';
+import { calculateHeight, fontStyleLight, fontStyleSemiBold } from '../Utility/shared';
 
 const prefixUnitWhitelist = ['$'];
 const suffixUnitWhitelist = ['%', '℉', '°F', '℃', '°C', '°'];
@@ -16,6 +16,9 @@ const defaultStyles = StyleSheet.create({
         maxWidth: '100%',
         flexDirection: 'row',
         alignItems: 'center',
+    },
+    unitsDefaultFont: {
+        ...fontStyleLight,
     },
 });
 
@@ -137,10 +140,11 @@ export const ChannelValue: React.FC<ChannelValueProps> = (props) => {
                                 {
                                     color: getColor(),
                                     fontSize: fontSize,
-                                    fontWeight: '300',
-                                    fontFamily: 'OpenSans-Regular',
+                                    // fontWeight: '300',
+                                    // fontFamily: 'OpenSans-Regular',
                                     lineHeight: calculateHeight(fontSize),
                                 },
+                                defaultStyles.unitsDefaultFont,
                                 styles.units,
                             ]}
                         >
@@ -182,8 +186,9 @@ export const ChannelValue: React.FC<ChannelValueProps> = (props) => {
                         color: getColor(),
                         fontSize: fontSize,
                         lineHeight: calculateHeight(fontSize),
-                        fontFamily: 'OpenSans-SemiBold',
-                        fontWeight: '600',
+                        // fontFamily: 'OpenSans-SemiBold',
+                        // fontWeight: '600',
+                        ...fontStyleSemiBold,
                     },
                 ]}
             >
@@ -194,8 +199,9 @@ export const ChannelValue: React.FC<ChannelValueProps> = (props) => {
                         {
                             color: getColor(),
                             fontSize: fontSize,
-                            fontFamily: 'OpenSans-SemiBold',
-                            fontWeight: '600',
+                            // fontFamily: 'OpenSans-SemiBold',
+                            // fontWeight: '600',
+                            ...fontStyleSemiBold,
                             lineHeight: calculateHeight(fontSize),
                         },
                         styles.value,

--- a/components/src/core/ChannelValue/ChannelValue.tsx
+++ b/components/src/core/ChannelValue/ChannelValue.tsx
@@ -140,8 +140,6 @@ export const ChannelValue: React.FC<ChannelValueProps> = (props) => {
                                 {
                                     color: getColor(),
                                     fontSize: fontSize,
-                                    // fontWeight: '300',
-                                    // fontFamily: 'OpenSans-Regular',
                                     lineHeight: calculateHeight(fontSize),
                                 },
                                 defaultStyles.unitsDefaultFont,
@@ -186,8 +184,6 @@ export const ChannelValue: React.FC<ChannelValueProps> = (props) => {
                         color: getColor(),
                         fontSize: fontSize,
                         lineHeight: calculateHeight(fontSize),
-                        // fontFamily: 'OpenSans-SemiBold',
-                        // fontWeight: '600',
                         ...fontStyleSemiBold,
                     },
                 ]}
@@ -199,8 +195,6 @@ export const ChannelValue: React.FC<ChannelValueProps> = (props) => {
                         {
                             color: getColor(),
                             fontSize: fontSize,
-                            // fontFamily: 'OpenSans-SemiBold',
-                            // fontWeight: '600',
                             ...fontStyleSemiBold,
                             lineHeight: calculateHeight(fontSize),
                         },

--- a/components/src/core/Chip/Chip.tsx
+++ b/components/src/core/Chip/Chip.tsx
@@ -9,6 +9,7 @@ import { $DeepPartial } from '@callstack/react-theme-provider';
 import { Icon } from '../Icon';
 import { IconSource } from '../__types__';
 import { ExtendedTheme, useExtendedTheme } from '@brightlayer-ui/react-native-themes';
+import { fontStyleRegular } from '../Utility/shared';
 
 /**
  * Props for the Chip component.
@@ -163,10 +164,7 @@ export const Chip: React.FC<ChipProps> = (props) => {
                         style,
                         chipStyle,
                     ]}
-                    textStyle={[
-                        { color: textColor ? textColor : DefaultTextColor, fontFamily: 'OpenSans-Regular' },
-                        textStyle,
-                    ]}
+                    textStyle={[{ color: textColor ? textColor : DefaultTextColor, ...fontStyleRegular }, textStyle]}
                     showSelectedCheck={false}
                     selected={selected}
                     disabled={disabled}
@@ -186,10 +184,7 @@ export const Chip: React.FC<ChipProps> = (props) => {
                         style,
                         chipStyle,
                     ]}
-                    textStyle={[
-                        { color: textColor ? textColor : DefaultTextColor, fontFamily: 'OpenSans-Regular' },
-                        textStyle,
-                    ]}
+                    textStyle={[{ color: textColor ? textColor : DefaultTextColor, ...fontStyleRegular }, textStyle]}
                     showSelectedCheck={false}
                     selected={selected}
                     disabled={disabled}
@@ -209,10 +204,7 @@ export const Chip: React.FC<ChipProps> = (props) => {
                         style,
                         chipStyle,
                     ]}
-                    textStyle={[
-                        { color: textColor ? textColor : DefaultTextColor, fontFamily: 'OpenSans-Regular' },
-                        textStyle,
-                    ]}
+                    textStyle={[{ color: textColor ? textColor : DefaultTextColor, ...fontStyleRegular }, textStyle]}
                     showSelectedCheck={false}
                     selected={selected}
                     disabled={disabled}

--- a/components/src/core/Chip/__snapshots__/Chip.test.tsx.snap
+++ b/components/src/core/Chip/__snapshots__/Chip.test.tsx.snap
@@ -136,6 +136,7 @@ exports[`Chip component renders correctly in elevated mode 1`] = `
                     {
                       "color": "rgba(73, 69, 79, 1)",
                       "fontFamily": "OpenSans-Regular",
+                      "fontWeight": "400",
                     },
                     undefined,
                   ],
@@ -288,6 +289,7 @@ exports[`Chip component renders correctly in outlined mode 1`] = `
                     {
                       "color": "rgba(73, 69, 79, 1)",
                       "fontFamily": "OpenSans-Regular",
+                      "fontWeight": "400",
                     },
                     undefined,
                   ],
@@ -440,6 +442,7 @@ exports[`Chip component renders correctly when disabled 1`] = `
                     {
                       "color": undefined,
                       "fontFamily": "OpenSans-Regular",
+                      "fontWeight": "400",
                     },
                     undefined,
                   ],
@@ -592,6 +595,7 @@ exports[`Chip component renders correctly when selected 1`] = `
                     {
                       "color": "rgba(33, 0, 93, 1)",
                       "fontFamily": "OpenSans-Regular",
+                      "fontWeight": "400",
                     },
                     undefined,
                   ],
@@ -814,6 +818,7 @@ exports[`Chip component renders correctly with an avatar 1`] = `
                     {
                       "color": "rgba(73, 69, 79, 1)",
                       "fontFamily": "OpenSans-Regular",
+                      "fontWeight": "400",
                     },
                     undefined,
                   ],
@@ -1004,6 +1009,7 @@ exports[`Chip component renders correctly with an icon 1`] = `
                     {
                       "color": "rgba(73, 69, 79, 1)",
                       "fontFamily": "OpenSans-Regular",
+                      "fontWeight": "400",
                     },
                     undefined,
                   ],
@@ -1156,6 +1162,7 @@ exports[`Chip component renders correctly with default props 1`] = `
                     {
                       "color": "rgba(73, 69, 79, 1)",
                       "fontFamily": "OpenSans-Regular",
+                      "fontWeight": "400",
                     },
                     undefined,
                   ],
@@ -1346,6 +1353,7 @@ exports[`Chip component renders only the icon when both an icon and an avatar ar
                     {
                       "color": "rgba(73, 69, 79, 1)",
                       "fontFamily": "OpenSans-Regular",
+                      "fontWeight": "400",
                     },
                     undefined,
                   ],

--- a/components/src/core/Drawer/DrawerHeader.tsx
+++ b/components/src/core/Drawer/DrawerHeader.tsx
@@ -20,6 +20,7 @@ import { useHeaderDimensions } from '../__hooks__/useHeaderDimensions';
 import { Icon } from '../Icon';
 import { useFontScale, useFontScaleSettings } from '../__contexts__/font-scale-context';
 import { ExtendedTheme, useExtendedTheme } from '@brightlayer-ui/react-native-themes';
+import { fontStyleRegular, fontStyleSemiBold } from '../Utility/shared';
 
 const makeStyles = (
     props: DrawerHeaderProps,
@@ -59,7 +60,8 @@ const makeStyles = (
             paddingVertical: 4 * fontScale,
             flex: 1,
             height: '100%',
-            fontFamily: 'OpenSans-SemiBold',
+            // fontFamily: 'OpenSans-SemiBold',
+            ...fontStyleSemiBold,
             justifyContent: 'center',
         },
         title: {
@@ -67,16 +69,18 @@ const makeStyles = (
             lineHeight: 32,
             fontSize: 24,
             letterSpacing: 0,
-            fontFamily: 'OpenSans-SemiBold',
-            fontWeight: '500',
+            // fontFamily: fontStyleSemiBold.fontFamily,
+            // fontWeight: fontStyleSemiBold.fontWeight,
+            ...fontStyleSemiBold,
         },
         subtitle: {
             color: props.fontColor || theme.colors.onSurfaceVariant,
             lineHeight: 20,
             fontSize: 14,
             letterSpacing: 0,
-            fontFamily: 'OpenSans-Regular',
-            fontWeight: '400',
+            // fontFamily: 'OpenSans-Regular',
+            // fontWeight: '400',
+            ...fontStyleRegular,
         },
         backgroundImageWrapper: {
             position: 'absolute',

--- a/components/src/core/Drawer/DrawerHeader.tsx
+++ b/components/src/core/Drawer/DrawerHeader.tsx
@@ -60,7 +60,6 @@ const makeStyles = (
             paddingVertical: 4 * fontScale,
             flex: 1,
             height: '100%',
-            // fontFamily: 'OpenSans-SemiBold',
             ...fontStyleSemiBold,
             justifyContent: 'center',
         },
@@ -69,8 +68,6 @@ const makeStyles = (
             lineHeight: 32,
             fontSize: 24,
             letterSpacing: 0,
-            // fontFamily: fontStyleSemiBold.fontFamily,
-            // fontWeight: fontStyleSemiBold.fontWeight,
             ...fontStyleSemiBold,
         },
         subtitle: {
@@ -78,8 +75,6 @@ const makeStyles = (
             lineHeight: 20,
             fontSize: 14,
             letterSpacing: 0,
-            // fontFamily: 'OpenSans-Regular',
-            // fontWeight: '400',
             ...fontStyleRegular,
         },
         backgroundImageWrapper: {

--- a/components/src/core/Drawer/DrawerNavGroup.tsx
+++ b/components/src/core/Drawer/DrawerNavGroup.tsx
@@ -9,6 +9,7 @@ import { NavGroupContext } from './context';
 import { EdgeInsets, useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useFontScale } from '../__contexts__/font-scale-context';
 import { ExtendedTheme, useExtendedTheme } from '@brightlayer-ui/react-native-themes';
+import { fontStyleSemiBold } from '../Utility/shared';
 
 export type DrawerNavGroupStyles = {
     root?: StyleProp<ViewStyle>;
@@ -65,8 +66,9 @@ const makeStyles = (
             letterSpacing: 2,
             lineHeight: 16,
             textTransform: 'uppercase',
-            fontFamily: 'OpenSans-SemiBold',
-            fontWeight: '600',
+            // fontFamily: 'OpenSans-SemiBold',
+            // fontWeight: '600',
+            ...fontStyleSemiBold,
         },
         divider: {
             position: 'absolute',

--- a/components/src/core/Drawer/DrawerNavGroup.tsx
+++ b/components/src/core/Drawer/DrawerNavGroup.tsx
@@ -66,8 +66,6 @@ const makeStyles = (
             letterSpacing: 2,
             lineHeight: 16,
             textTransform: 'uppercase',
-            // fontFamily: 'OpenSans-SemiBold',
-            // fontWeight: '600',
             ...fontStyleSemiBold,
         },
         divider: {

--- a/components/src/core/Drawer/DrawerNavItem.tsx
+++ b/components/src/core/Drawer/DrawerNavItem.tsx
@@ -329,14 +329,10 @@ export const DrawerNavItem: React.FC<DrawerNavItemProps> = (props) => {
                                 title: Object.assign(
                                     active || (isInActiveTree && !disableActiveItemParentStyles)
                                         ? {
-                                              //   fontWeight: 600,
-                                              //   fontFamily: 'OpenSans-SemiBold',
                                               ...fontStyleSemiBold,
                                               color: theme.colors.onPrimaryContainer,
                                           }
                                         : {
-                                              //   fontWeight: 400,
-                                              //   fontFamily: 'OpenSans-Regular',
                                               ...fontStyleRegular,
                                               color: theme.colors.onSurface,
                                           },

--- a/components/src/core/Drawer/DrawerNavItem.tsx
+++ b/components/src/core/Drawer/DrawerNavItem.tsx
@@ -13,6 +13,7 @@ import { Icon } from '../Icon';
 import { useFontScale, useFontScaleSettings } from '../__contexts__/font-scale-context';
 import MatIcon from 'react-native-vector-icons/MaterialIcons';
 import { ExtendedTheme, useExtendedTheme } from '@brightlayer-ui/react-native-themes';
+import { fontStyleRegular, fontStyleSemiBold } from '../Utility/shared';
 
 export type DrawerNavItemStyles = {
     root?: StyleProp<ViewStyle>;
@@ -328,13 +329,15 @@ export const DrawerNavItem: React.FC<DrawerNavItemProps> = (props) => {
                                 title: Object.assign(
                                     active || (isInActiveTree && !disableActiveItemParentStyles)
                                         ? {
-                                              fontWeight: 600,
-                                              fontFamily: 'OpenSans-SemiBold',
+                                              //   fontWeight: 600,
+                                              //   fontFamily: 'OpenSans-SemiBold',
+                                              ...fontStyleSemiBold,
                                               color: theme.colors.onPrimaryContainer,
                                           }
                                         : {
-                                              fontWeight: 400,
-                                              fontFamily: 'OpenSans-Regular',
+                                              //   fontWeight: 400,
+                                              //   fontFamily: 'OpenSans-Regular',
+                                              ...fontStyleRegular,
                                               color: theme.colors.onSurface,
                                           },
                                     iliTitle

--- a/components/src/core/Grade/Grade.tsx
+++ b/components/src/core/Grade/Grade.tsx
@@ -4,7 +4,7 @@
  */
 
 import React from 'react';
-import { Platform, ViewProps } from 'react-native';
+import { ViewProps } from 'react-native';
 import { Avatar } from 'react-native-paper';
 import { $DeepPartial } from '@callstack/react-theme-provider';
 import { ExtendedTheme, useExtendedTheme } from '@brightlayer-ui/react-native-themes';

--- a/components/src/core/Grade/Grade.tsx
+++ b/components/src/core/Grade/Grade.tsx
@@ -8,6 +8,7 @@ import { Platform, ViewProps } from 'react-native';
 import { Avatar } from 'react-native-paper';
 import { $DeepPartial } from '@callstack/react-theme-provider';
 import { ExtendedTheme, useExtendedTheme } from '@brightlayer-ui/react-native-themes';
+import { fontStyleSemiBold } from '../Utility/shared';
 
 /**
  * Props for the Grade component.
@@ -98,8 +99,9 @@ const GradeBase = (props: GradeProps): JSX.Element => {
     // Define styles for text within Avatar.Text
     const textStyle = {
         color: fontColor || theme.colors.onPrimary,
-        fontFamily: 'OpenSans-Bold',
-        fontWeight: Platform.OS === 'ios' ? ('700' as const) : ('600' as const),
+        // fontFamily: 'OpenSans-Bold',
+        ...fontStyleSemiBold,
+        fontWeight: Platform.OS === 'ios' ? ('700' as const) : ('600' as const), // check with Arshdeep
     };
 
     return (

--- a/components/src/core/Grade/Grade.tsx
+++ b/components/src/core/Grade/Grade.tsx
@@ -8,7 +8,7 @@ import { Platform, ViewProps } from 'react-native';
 import { Avatar } from 'react-native-paper';
 import { $DeepPartial } from '@callstack/react-theme-provider';
 import { ExtendedTheme, useExtendedTheme } from '@brightlayer-ui/react-native-themes';
-import { fontStyleSemiBold } from '../Utility/shared';
+import { fontStyleBold } from '../Utility/shared';
 
 /**
  * Props for the Grade component.
@@ -99,9 +99,7 @@ const GradeBase = (props: GradeProps): JSX.Element => {
     // Define styles for text within Avatar.Text
     const textStyle = {
         color: fontColor || theme.colors.onPrimary,
-        // fontFamily: 'OpenSans-Bold',
-        ...fontStyleSemiBold,
-        fontWeight: Platform.OS === 'ios' ? ('700' as const) : ('600' as const), // check with Arshdeep
+        ...fontStyleBold,
     };
 
     return (

--- a/components/src/core/Header/HeaderContent.tsx
+++ b/components/src/core/Header/HeaderContent.tsx
@@ -18,6 +18,7 @@ import { useHeaderHeight } from './contexts/HeaderHeightContextProvider';
 import { useHeaderDimensions } from '../__hooks__/useHeaderDimensions';
 import { useFontScale, useFontScaleSettings } from '../__contexts__/font-scale-context';
 import { ExtendedTheme } from '@brightlayer-ui/react-native-themes';
+import { fontStyleRegular, fontStyleSemiBold } from '../Utility/shared';
 
 const headerContentStyles = StyleSheet.create({
     titleContainer: {
@@ -65,7 +66,8 @@ const HeaderTitle: React.FC<HeaderTitleProps> = (props) => {
     const getTitleStyle = useCallback(
         () => ({
             color: textColor,
-            fontFamily: 'OpenSans-SemiBold',
+            // fontFamily: 'OpenSans-SemiBold',
+            ...fontStyleSemiBold,
             fontSize: headerHeight.interpolate({
                 inputRange: [REGULAR_HEIGHT, EXTENDED_HEIGHT],
                 outputRange: [20, 30],
@@ -121,7 +123,8 @@ const HeaderSubtitle: React.FC<HeaderSubtitleProps> = (props) => {
     const getSubtitleStyle = useCallback(
         () => ({
             color: textColor,
-            fontFamily: 'OpenSans-Regular',
+            // fontFamily: 'OpenSans-Regular',
+            ...fontStyleRegular,
             fontSize: headerHeight.interpolate({
                 inputRange: [REGULAR_HEIGHT, EXTENDED_HEIGHT],
                 outputRange: [14, 16],
@@ -191,7 +194,8 @@ const HeaderInfo: React.FC<HeaderInfoProps> = (props) => {
                 outputRange: [0, 1],
                 extrapolate: 'clamp',
             }),
-            fontFamily: 'OpenSans-Regular',
+            // fontFamily: 'OpenSans-Regular',
+            ...fontStyleRegular,
             fontSize: headerHeight.interpolate({
                 inputRange: [REGULAR_HEIGHT, EXTENDED_HEIGHT],
                 outputRange: [0.1, 14],

--- a/components/src/core/Header/HeaderContent.tsx
+++ b/components/src/core/Header/HeaderContent.tsx
@@ -66,7 +66,6 @@ const HeaderTitle: React.FC<HeaderTitleProps> = (props) => {
     const getTitleStyle = useCallback(
         () => ({
             color: textColor,
-            // fontFamily: 'OpenSans-SemiBold',
             ...fontStyleSemiBold,
             fontSize: headerHeight.interpolate({
                 inputRange: [REGULAR_HEIGHT, EXTENDED_HEIGHT],
@@ -123,7 +122,6 @@ const HeaderSubtitle: React.FC<HeaderSubtitleProps> = (props) => {
     const getSubtitleStyle = useCallback(
         () => ({
             color: textColor,
-            // fontFamily: 'OpenSans-Regular',
             ...fontStyleRegular,
             fontSize: headerHeight.interpolate({
                 inputRange: [REGULAR_HEIGHT, EXTENDED_HEIGHT],
@@ -194,7 +192,6 @@ const HeaderInfo: React.FC<HeaderInfoProps> = (props) => {
                 outputRange: [0, 1],
                 extrapolate: 'clamp',
             }),
-            // fontFamily: 'OpenSans-Regular',
             ...fontStyleRegular,
             fontSize: headerHeight.interpolate({
                 inputRange: [REGULAR_HEIGHT, EXTENDED_HEIGHT],

--- a/components/src/core/Hero/Hero.tsx
+++ b/components/src/core/Hero/Hero.tsx
@@ -43,8 +43,6 @@ const makeStyles = (theme: ExtendedTheme, fontScale: number): StyleSheet.NamedSt
             width: '100%',
             overflow: 'hidden',
             textAlign: 'center',
-            // fontFamily: 'OpenSans-SemiBold',
-            // fontWeight: '600',
             ...fontStyleSemiBold,
             color: theme.colors.onSurfaceVariant,
         },

--- a/components/src/core/Hero/Hero.tsx
+++ b/components/src/core/Hero/Hero.tsx
@@ -7,6 +7,7 @@ import { Icon } from '../Icon';
 import { IconSource } from '../__types__';
 import { useFontScale } from '../__contexts__/font-scale-context';
 import { ExtendedTheme, useExtendedTheme } from '@brightlayer-ui/react-native-themes';
+import { fontStyleSemiBold } from '../Utility/shared';
 
 type HeroStyles = {
     root?: ViewStyle;
@@ -42,8 +43,9 @@ const makeStyles = (theme: ExtendedTheme, fontScale: number): StyleSheet.NamedSt
             width: '100%',
             overflow: 'hidden',
             textAlign: 'center',
-            fontFamily: 'OpenSans-SemiBold',
-            fontWeight: '600',
+            // fontFamily: 'OpenSans-SemiBold',
+            // fontWeight: '600',
+            ...fontStyleSemiBold,
             color: theme.colors.onSurfaceVariant,
         },
     });

--- a/components/src/core/InfoListItem/InfoListItem.tsx
+++ b/components/src/core/InfoListItem/InfoListItem.tsx
@@ -17,6 +17,7 @@ import { Icon } from '../Icon';
 import { IconSource } from '../__types__';
 import { useFontScale, useFontScaleSettings } from '../__contexts__/font-scale-context';
 import { ExtendedTheme, useExtendedTheme } from '@brightlayer-ui/react-native-themes';
+import { fontStyleSemiBold } from '../Utility/shared';
 
 type IconAlign = 'left' | 'center' | 'right';
 
@@ -101,8 +102,9 @@ const infoListItemStyles = (
         },
         title: {
             color: props.fontColor || theme.colors.onSurface,
-            fontFamily: 'OpenSans-Bold',
-            fontWeight: '600',
+            // fontFamily: 'OpenSans-Bold',
+            // fontWeight: '600',
+            ...fontStyleSemiBold,
         },
         subtitleWrapper: {
             flexDirection: 'row',

--- a/components/src/core/InfoListItem/InfoListItem.tsx
+++ b/components/src/core/InfoListItem/InfoListItem.tsx
@@ -102,8 +102,6 @@ const infoListItemStyles = (
         },
         title: {
             color: props.fontColor || theme.colors.onSurface,
-            // fontFamily: 'OpenSans-Bold',
-            // fontWeight: '600',
             ...fontStyleSemiBold,
         },
         subtitleWrapper: {

--- a/components/src/core/ListItemTag/ListItemTag.tsx
+++ b/components/src/core/ListItemTag/ListItemTag.tsx
@@ -3,7 +3,7 @@ import { TextStyle, StyleProp, StyleSheet } from 'react-native';
 import { Text, TextProps } from 'react-native-paper';
 import { useFontScale } from '../__contexts__/font-scale-context';
 import { $DeepPartial } from '@callstack/react-theme-provider';
-import { calculateHeight } from '../Utility/shared';
+import { calculateHeight, fontStyleBold } from '../Utility/shared';
 import { ExtendedTheme, useExtendedTheme } from '@brightlayer-ui/react-native-themes';
 
 export type ListItemTagProps = Omit<TextProps<'bodyMedium'>, 'children' | 'theme' | 'variant'> & {
@@ -55,7 +55,7 @@ const listItemTagStyles = (
             paddingLeft: 4 * fontScale,
             paddingRight: 3 * fontScale, // to account for the 1px letter spacing on the last letter
             borderRadius: 4 * fontScale,
-            fontFamily: 'OpenSans-Bold',
+            ...fontStyleBold,
             overflow: 'hidden',
             lineHeight: calculateHeight(fontSize),
             fontSize,

--- a/components/src/core/ListItemTag/__snapshots__/ListItemTag.test.tsx.snap
+++ b/components/src/core/ListItemTag/__snapshots__/ListItemTag.test.tsx.snap
@@ -28,6 +28,7 @@ exports[`ListItemTag ListItemTag Renders 1`] = `
             "color": undefined,
             "fontFamily": "OpenSans-Bold",
             "fontSize": 10,
+            "fontWeight": "700",
             "height": 32,
             "letterSpacing": 1,
             "lineHeight": 16,

--- a/components/src/core/UserMenu/UserMenu.tsx
+++ b/components/src/core/UserMenu/UserMenu.tsx
@@ -7,6 +7,7 @@ import { $DeepPartial } from '@callstack/react-theme-provider';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useFontScale } from '../__contexts__/font-scale-context';
 import { ExtendedTheme, useExtendedTheme } from '@brightlayer-ui/react-native-themes';
+import { fontStyleSemiBold } from '../Utility/shared';
 
 export type UserMenuProps = {
     /** Avatar component to display as the menu trigger */
@@ -143,7 +144,8 @@ export const UserMenu: React.FC<UserMenuProps> = (props) => {
                                     title: Object.assign(
                                         {
                                             fontSize: 16,
-                                            fontFamily: 'OpenSans-SemiBold',
+                                            // fontFamily: 'OpenSans-SemiBold',
+                                            ...fontStyleSemiBold,
                                         },
                                         menuItemStyles.title
                                     ),

--- a/components/src/core/UserMenu/UserMenu.tsx
+++ b/components/src/core/UserMenu/UserMenu.tsx
@@ -144,7 +144,6 @@ export const UserMenu: React.FC<UserMenuProps> = (props) => {
                                     title: Object.assign(
                                         {
                                             fontSize: 16,
-                                            // fontFamily: 'OpenSans-SemiBold',
                                             ...fontStyleSemiBold,
                                         },
                                         menuItemStyles.title

--- a/components/src/core/Utility/shared.tsx
+++ b/components/src/core/Utility/shared.tsx
@@ -9,3 +9,4 @@ export const fontStyleLight = useFontWeight('300');
 export const fontStyleRegular = useFontWeight('400');
 export const fontStyleSemiBold = useFontWeight('600');
 export const fontStyleBold = useFontWeight('700');
+export const fontStyleExtraBold = useFontWeight('800');

--- a/components/src/core/Utility/shared.tsx
+++ b/components/src/core/Utility/shared.tsx
@@ -1,5 +1,5 @@
 import { MD3Theme } from 'react-native-paper';
-import { useFontWeight } from '@brightlayer-ui/react-native-themes'; // Add this import statement
+import { useFontWeight } from '@brightlayer-ui/react-native-themes';
 
 export const getPrimary500 = (theme: MD3Theme): string | undefined => theme.colors.primary;
 

--- a/components/src/core/Utility/shared.tsx
+++ b/components/src/core/Utility/shared.tsx
@@ -1,5 +1,11 @@
 import { MD3Theme } from 'react-native-paper';
+import { useFontWeight } from '@brightlayer-ui/react-native-themes'; // Add this import statement
 
 export const getPrimary500 = (theme: MD3Theme): string | undefined => theme.colors.primary;
 
 export const calculateHeight = (fontSize: number): number => Math.ceil((fontSize * 1.25) / 4) * 4;
+
+export const fontStyleLight = useFontWeight('300');
+export const fontStyleRegular = useFontWeight('400');
+export const fontStyleSemiBold = useFontWeight('600');
+export const fontStyleBold = useFontWeight('700');

--- a/components/yarn.lock
+++ b/components/yarn.lock
@@ -823,10 +823,10 @@
   resolved "https://registry.yarnpkg.com/@brightlayer-ui/prettier-config/-/prettier-config-1.0.3.tgz#e40a7ae7435c6fd5118acbf249080e0aa81e93af"
   integrity sha512-EYm3+V7Qd+oYEF+8FadsXAZqXryEHHbGnrV1BMp9selhABjceqUqXPVE4Sn3SKWQdBNJ3En2A3EzgrzRbvRTaw==
 
-"@brightlayer-ui/react-native-themes@7.0.1-alpha.3":
-  version "7.0.1-alpha.3"
-  resolved "https://registry.yarnpkg.com/@brightlayer-ui/react-native-themes/-/react-native-themes-7.0.1-alpha.3.tgz#a0d3c82b47cd4938e1882b42e0c21546c92f55b0"
-  integrity sha512-cQd95o84WVb8PFAkbxgrzwwkDn7x6KTxsLdi6INL2U0hX/eE/e4/7V6261wObRGApOdM9s/1mKMnIVZZrGv5WA==
+"@brightlayer-ui/react-native-themes@7.0.1-alpha.4":
+  version "7.0.1-alpha.4"
+  resolved "https://registry.yarnpkg.com/@brightlayer-ui/react-native-themes/-/react-native-themes-7.0.1-alpha.4.tgz#b88a5defe26d065e89eeeb98c59d329c8469dd41"
+  integrity sha512-lDDGlf3Blr2PIh6RaLB3ZCWOtaVIlEJ+TpEU7jxVJ6mOuFWiH4AsVLXdlhjxP2HfOUc0f6sENejCvtsSCVdWzw==
   dependencies:
     "@brightlayer-ui/colors" "4.0.0"
     color "^4.2.3"

--- a/components/yarn.lock
+++ b/components/yarn.lock
@@ -823,10 +823,10 @@
   resolved "https://registry.yarnpkg.com/@brightlayer-ui/prettier-config/-/prettier-config-1.0.3.tgz#e40a7ae7435c6fd5118acbf249080e0aa81e93af"
   integrity sha512-EYm3+V7Qd+oYEF+8FadsXAZqXryEHHbGnrV1BMp9selhABjceqUqXPVE4Sn3SKWQdBNJ3En2A3EzgrzRbvRTaw==
 
-"@brightlayer-ui/react-native-themes@7.0.0":
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/@brightlayer-ui/react-native-themes/-/react-native-themes-7.0.0.tgz#5a61f853d9f308453174802a404dbb2332f75174"
-  integrity sha512-2CYetnzjawvXjspHxw3wVv5PyDu3dKPfEQ2RkJpxV5+/ixjqJAUM5kryO63cdNTEuMYvjQEz5R3vRaHnj/uxVA==
+"@brightlayer-ui/react-native-themes@7.0.1-alpha.3":
+  version "7.0.1-alpha.3"
+  resolved "https://registry.yarnpkg.com/@brightlayer-ui/react-native-themes/-/react-native-themes-7.0.1-alpha.3.tgz#a0d3c82b47cd4938e1882b42e0c21546c92f55b0"
+  integrity sha512-cQd95o84WVb8PFAkbxgrzwwkDn7x6KTxsLdi6INL2U0hX/eE/e4/7V6261wObRGApOdM9s/1mKMnIVZZrGv5WA==
   dependencies:
     "@brightlayer-ui/colors" "4.0.0"
     color "^4.2.3"

--- a/components/yarn.lock
+++ b/components/yarn.lock
@@ -823,10 +823,10 @@
   resolved "https://registry.yarnpkg.com/@brightlayer-ui/prettier-config/-/prettier-config-1.0.3.tgz#e40a7ae7435c6fd5118acbf249080e0aa81e93af"
   integrity sha512-EYm3+V7Qd+oYEF+8FadsXAZqXryEHHbGnrV1BMp9selhABjceqUqXPVE4Sn3SKWQdBNJ3En2A3EzgrzRbvRTaw==
 
-"@brightlayer-ui/react-native-themes@7.0.1-alpha.4":
-  version "7.0.1-alpha.4"
-  resolved "https://registry.yarnpkg.com/@brightlayer-ui/react-native-themes/-/react-native-themes-7.0.1-alpha.4.tgz#b88a5defe26d065e89eeeb98c59d329c8469dd41"
-  integrity sha512-lDDGlf3Blr2PIh6RaLB3ZCWOtaVIlEJ+TpEU7jxVJ6mOuFWiH4AsVLXdlhjxP2HfOUc0f6sENejCvtsSCVdWzw==
+"@brightlayer-ui/react-native-themes@7.0.1-alpha.5":
+  version "7.0.1-alpha.5"
+  resolved "https://registry.yarnpkg.com/@brightlayer-ui/react-native-themes/-/react-native-themes-7.0.1-alpha.5.tgz#8e1508606c5e670ad434ffcc82781af3118e2a28"
+  integrity sha512-D99P8QiHzNEPZdzd8XFEGTmg/M0rcwiBF7fKpaT1PlqlXFVteAJHS+bCK3yC7LQlrK5eQ0YqJROhtVMZVT478Q==
   dependencies:
     "@brightlayer-ui/colors" "4.0.0"
     color "^4.2.3"


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
Fixes # .
Use https://github.com/etn-ccis/blui-react-native-showcase-demo/pull/187 for showcase branch
<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- 
- 
- 

<!-- Include screenshots if they will help illustrate the changes in this PR -->
#### Screenshots / Screen Recording (if applicable)
-


<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->
#### To Test:
- you can inspect the components mentioned in this issue https://github.com/etn-ccis/blui-react-native-component-library/issues/559

- and check whether it has to have the correct fontWeight and fontFamilty.
- Also you can use following code snippet to test:
fontStyleBold = useFontWeight('700');
<Text variant={'headlineLarge'} style={{ ...fontStyleBold }}>
    headlineLarge
</Text>


<!-- Useful for draft pull requests -->
#### Any specific feedback you are looking for?
-


